### PR TITLE
Implement timing parity between GRID <> emulation

### DIFF
--- a/GRID/App.h
+++ b/GRID/App.h
@@ -1,6 +1,7 @@
 #ifndef APP_H
 #define APP_H
 
+#include "AppContext.h"
 #include "helpers.h"
 #include "Scene.h"
 #include <memory>
@@ -15,11 +16,11 @@
 // App manages the current scene; only holds Matrix32&
 class App
 {
-    Matrix32 &gfx;
+    AppContext ctx;
     std::unique_ptr<Scene> current;
 
 public:
-    explicit App(Matrix32 &g) : gfx(g) {}
+    explicit App(Matrix32 &gfx) : ctx{gfx} {}
 
     // Replace the current scene with a newly constructed SceneT.
     // - Destroys the old scene, creates SceneT(args...), then calls setup(gfx).
@@ -31,17 +32,17 @@ public:
         static_assert(std::is_base_of<Scene, SceneT>::value, "SceneT must derive from Scene");
         current.reset(new SceneT(std::forward<Args>(args)...));
         
-        // Immediate only during setup (works on SDLMatrix32, no-op on Arduino)
-        gfx.setImmediate(true);
-        current->setup(gfx);
-        gfx.setImmediate(false);
+        // immediate only during setup (works on SDLMatrix32, no-op on Arduino)
+        ctx.gfx.setImmediate(true);
+        current->setup(ctx);
+        ctx.gfx.setImmediate(false);
     }
 
     // Call the current scene's loop(gfx, dt).
     // dt is in milliseconds.
     void loopOnce(millis_t dt)
     {
-        current->loop(gfx, dt);
+        current->loop(ctx, dt);
     }
 };
 

--- a/GRID/App.h
+++ b/GRID/App.h
@@ -31,7 +31,10 @@ public:
     {
         static_assert(std::is_base_of<Scene, SceneT>::value, "SceneT must derive from Scene");
         current.reset(new SceneT(std::forward<Args>(args)...));
-        
+        // apply preferred timing
+        auto prefs = current->timingPrefs();
+        ctx.time.setTargetHz(prefs.targetHz);
+        ctx.time.resetSceneClock();
         // immediate only during setup (works on SDLMatrix32, no-op on Arduino)
         ctx.gfx.setImmediate(true);
         current->setup(ctx);

--- a/GRID/App.h
+++ b/GRID/App.h
@@ -20,7 +20,7 @@ class App
     std::unique_ptr<Scene> current;
 
 public:
-    explicit App(Matrix32 &gfx) : ctx{gfx} {}
+    explicit App(Matrix32 &gfx, Timing &time) : ctx{gfx, time} {}
 
     // Replace the current scene with a newly constructed SceneT.
     // - Destroys the old scene, creates SceneT(args...), then calls setup(gfx).
@@ -38,11 +38,11 @@ public:
         ctx.gfx.setImmediate(false);
     }
 
-    // Call the current scene's loop(gfx, dt).
+    // Call the current scene's loop(ctx).
     // dt is in milliseconds.
-    void loopOnce(millis_t dt)
+    void loopOnce()
     {
-        current->loop(ctx, dt);
+        current->loop(ctx);
     }
 };
 

--- a/GRID/App.h
+++ b/GRID/App.h
@@ -33,7 +33,7 @@ public:
         current.reset(new SceneT(std::forward<Args>(args)...));
         // apply preferred timing
         auto prefs = current->timingPrefs();
-        ctx.time.setTargetHz(prefs.targetHz);
+        ctx.time.applyPreference(prefs);
         ctx.time.resetSceneClock();
         // immediate only during setup (works on SDLMatrix32, no-op on Arduino)
         ctx.gfx.setImmediate(true);

--- a/GRID/AppContext.h
+++ b/GRID/AppContext.h
@@ -2,10 +2,12 @@
 #define APP_CONTEXT_H
 
 #include "Matrix32.h"
+#include "Timing.h"
 
 struct AppContext
 {
-    Matrix32 &gfx;
+    Matrix32    &gfx;   // reference to Matrix 32x32 graphics
+    Timing      &time;  // reference to timing interface
 };
 
 #endif // APP_CONTEXT_H

--- a/GRID/AppContext.h
+++ b/GRID/AppContext.h
@@ -1,0 +1,11 @@
+#ifndef APP_CONTEXT_H
+#define APP_CONTEXT_H
+
+#include "Matrix32.h"
+
+struct AppContext
+{
+    Matrix32 &gfx;
+};
+
+#endif // APP_CONTEXT_H

--- a/GRID/AppContext.h
+++ b/GRID/AppContext.h
@@ -6,8 +6,8 @@
 
 struct AppContext
 {
-    Matrix32    &gfx;   // reference to Matrix 32x32 graphics
-    Timing      &time;  // reference to timing interface
+    Matrix32 &gfx; // reference to Matrix 32x32 graphics
+    Timing &time;  // reference to timing interface
 };
 
 #endif // APP_CONTEXT_H

--- a/GRID/ArduinoPassiveTiming.h
+++ b/GRID/ArduinoPassiveTiming.h
@@ -1,0 +1,57 @@
+#ifndef ARDUINO_PASSIVE_TIMING_H
+#define ARDUINO_PASSIVE_TIMING_H
+
+// ArduinoPassiveTiming.h
+#include "Timing.h"
+#include "helpers.h"
+#include <Arduino.h>
+
+/**
+ * @brief A simple Timing implementation for Arduino that just reflects millis()
+ * and provides a fixed nominal dt based on targetHz, but does not do any
+ * cadence control (no sleeping or frame skipping).
+ */
+class ArduinoPassiveTiming final : public Timing
+{
+    const double defaultTargetHz_{ 60.0 };
+    double targetHz_;
+    float dtMs_;
+    uint32_t startMs_;
+
+public:
+    explicit ArduinoPassiveTiming(double targetHz)
+        : defaultTargetHz_(targetHz), targetHz_(targetHz),
+          dtMs_(static_cast<float>(millisPerSec / targetHz)),
+          startMs_(millis()) {}
+
+    // No cadence control; just reflect Arduino time
+    uint32_t nowMs() const override { return millis() - startMs_; }
+    float dtMs() const override { return dtMs_; } // nominal
+    float fps() const override { return static_cast<float>(targetHz_); }
+    double targetHz() const override { return targetHz_; }
+    
+    // When there is a preferred timing, apply it; otherwise use default
+    void applyPreference(SceneTimingPrefs pref) override
+    {
+        if (isnan(pref.targetHz))
+            setTargetHz(defaultTargetHz_);
+        else
+            setTargetHz(pref.targetHz);
+    }
+
+    void setTargetHz(double hz) override
+    {
+        targetHz_ = hz;
+        dtMs_ = static_cast<float>(millisPerSec / targetHz_);
+    }
+    void resetSceneClock() override
+    {
+        startMs_ = millis();
+    }
+    void sleep(millis_t ms) override
+    {
+        delay(ms);
+    }
+};
+
+#endif // ARDUINO_PASSIVE_TIMING_H

--- a/GRID/BoidsScene.cpp
+++ b/GRID/BoidsScene.cpp
@@ -153,7 +153,7 @@ void BoidsScene::drawBoid(Matrix32 &gfx, Boid* boid)
     gfx.drawPixel(x, y, color);
 }
 
-void BoidsScene::setup(Matrix32 &gfx)
+void BoidsScene::setup(AppContext &ctx)
 {
     // position boids
     for (int i = 0; i < N_BOIDS; i++)
@@ -162,19 +162,19 @@ void BoidsScene::setup(Matrix32 &gfx)
     }
 }
 
-void BoidsScene::loop(Matrix32 &gfx, millis_t dt)
+void BoidsScene::loop(AppContext &ctx, millis_t dt)
 {
     // Clear background
-    gfx.clear();
+    ctx.gfx.clear();
 
     // update flock
     for (int i = 0; i < N_BOIDS; i++)
     {
         Boid* boid = &flock[i];
         updateBoid(boid, flock);
-        drawBoid(gfx, boid);
+        drawBoid(ctx.gfx, boid);
     }
 
     // show the frame
-    gfx.show();
+    ctx.gfx.show();
 }

--- a/GRID/BoidsScene.cpp
+++ b/GRID/BoidsScene.cpp
@@ -11,12 +11,12 @@
  */
 void BoidsScene::placeBoid(Boid* boid)
 {
-    boid->position.x = random(MATRIX_WIDTH);
-    boid->position.y = random(MATRIX_HEIGHT);
+    boid->position.x = Helpers::random(MATRIX_WIDTH);
+    boid->position.y = Helpers::random(MATRIX_HEIGHT);
     long choice;
-    choice = random(1000);
+    choice = Helpers::random(1000);
     boid->velocity.x = ((choice % 2) ? 1 : -1) * (0.5 * MIN_SPEED + (MAX_SPEED - MIN_SPEED) * (choice / 1000.0));
-    choice = random();
+    choice = Helpers::random();
     boid->velocity.y = ((choice % 2) ? 1 : -1) * (0.5 * MIN_SPEED + (MAX_SPEED - MIN_SPEED) * (choice / 1000.0));
 }
 

--- a/GRID/BoidsScene.cpp
+++ b/GRID/BoidsScene.cpp
@@ -16,7 +16,7 @@ void BoidsScene::placeBoid(Boid* boid)
     long choice;
     choice = Helpers::random(1000);
     boid->velocity.x = ((choice % 2) ? 1 : -1) * (0.5 * MIN_SPEED + (MAX_SPEED - MIN_SPEED) * (choice / 1000.0));
-    choice = Helpers::random();
+    choice = Helpers::random(1000);
     boid->velocity.y = ((choice % 2) ? 1 : -1) * (0.5 * MIN_SPEED + (MAX_SPEED - MIN_SPEED) * (choice / 1000.0));
 }
 
@@ -162,7 +162,7 @@ void BoidsScene::setup(AppContext &ctx)
     }
 }
 
-void BoidsScene::loop(AppContext &ctx, millis_t dt)
+void BoidsScene::loop(AppContext &ctx)
 {
     // Clear background
     ctx.gfx.clear();

--- a/GRID/BoidsScene.h
+++ b/GRID/BoidsScene.h
@@ -50,8 +50,8 @@ class BoidsScene final : public Scene
     void drawBoid(Matrix32 &gfx, Boid* boid);
 
   public:
-    void setup(Matrix32 &gfx) override;
-    void loop(Matrix32 &gfx, millis_t dt) override;
+    void setup(AppContext &ctx) override;
+    void loop(AppContext &ctx, millis_t dt) override;
 };
 
 #endif

--- a/GRID/BoidsScene.h
+++ b/GRID/BoidsScene.h
@@ -51,7 +51,7 @@ class BoidsScene final : public Scene
 
   public:
     void setup(AppContext &ctx) override;
-    void loop(AppContext &ctx, millis_t dt) override;
+    void loop(AppContext &ctx) override;
 };
 
 #endif

--- a/GRID/BoidsScene.h
+++ b/GRID/BoidsScene.h
@@ -50,6 +50,8 @@ class BoidsScene final : public Scene
     void drawBoid(Matrix32 &gfx, Boid* boid);
 
   public:
+    // matched measured hardware (~16.6 Hz)
+    SceneTimingPrefs timingPrefs() const override { return {16.6}; }
     void setup(AppContext &ctx) override;
     void loop(AppContext &ctx) override;
 };

--- a/GRID/ExampleScene.cpp
+++ b/GRID/ExampleScene.cpp
@@ -1,34 +1,34 @@
 #include "ExampleScene.h"
 #include "Matrix32.h"
 #include "Colors.h"
-#include "helpers.h" // for delay()
+#include "helpers.h"
 
 void ExampleScene::setup(AppContext &ctx)
 {
     // draw a pixel in solid white
     ctx.gfx.drawPixel(0, 0, WHITE);
-    delay(500);
+    Helpers::sleep(500);
 
     // fix the screen with green
     ctx.gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, GREEN);
-    delay(500);
+    Helpers::sleep(500);
 
     // draw a box in yellow
     ctx.gfx.drawRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, YELLOW);
-    delay(500);
+    Helpers::sleep(500);
 
     // draw an 'X' in red
     ctx.gfx.drawLine(0, 0, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 1, RED);
     ctx.gfx.drawLine(MATRIX_WIDTH - 1, 0, 0, MATRIX_HEIGHT - 1, RED);
-    delay(500);
+    Helpers::sleep(500);
 
     // draw a blue circle
     ctx.gfx.drawCircle(10, 10, 10, BLUE);
-    delay(500);
+    Helpers::sleep(500);
 
     // fill a violet circle
     ctx.gfx.fillCircle(21, 21, 10, VIOLET);
-    delay(500);
+    Helpers::sleep(500);
 
     ctx.gfx.clear();
 

--- a/GRID/ExampleScene.cpp
+++ b/GRID/ExampleScene.cpp
@@ -67,7 +67,7 @@ void ExampleScene::setup(AppContext &ctx)
     // whew!
 }
 
-void ExampleScene::loop(AppContext &ctx, millis_t dt)
+void ExampleScene::loop(AppContext &ctx)
 {
     // Do nothing -- image doesn't change
 }

--- a/GRID/ExampleScene.cpp
+++ b/GRID/ExampleScene.cpp
@@ -1,72 +1,73 @@
 #include "ExampleScene.h"
+#include "Matrix32.h"
 #include "Colors.h"
 #include "helpers.h" // for delay()
 
-void ExampleScene::setup(Matrix32 &gfx)
+void ExampleScene::setup(AppContext &ctx)
 {
     // draw a pixel in solid white
-    gfx.drawPixel(0, 0, WHITE);
+    ctx.gfx.drawPixel(0, 0, WHITE);
     delay(500);
 
     // fix the screen with green
-    gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, GREEN);
+    ctx.gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, GREEN);
     delay(500);
 
     // draw a box in yellow
-    gfx.drawRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, YELLOW);
+    ctx.gfx.drawRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, YELLOW);
     delay(500);
 
     // draw an 'X' in red
-    gfx.drawLine(0, 0, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 1, RED);
-    gfx.drawLine(MATRIX_WIDTH - 1, 0, 0, MATRIX_HEIGHT - 1, RED);
+    ctx.gfx.drawLine(0, 0, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 1, RED);
+    ctx.gfx.drawLine(MATRIX_WIDTH - 1, 0, 0, MATRIX_HEIGHT - 1, RED);
     delay(500);
 
     // draw a blue circle
-    gfx.drawCircle(10, 10, 10, BLUE);
+    ctx.gfx.drawCircle(10, 10, 10, BLUE);
     delay(500);
 
     // fill a violet circle
-    gfx.fillCircle(21, 21, 10, VIOLET);
+    ctx.gfx.fillCircle(21, 21, 10, VIOLET);
     delay(500);
 
-    gfx.clear();
+    ctx.gfx.clear();
 
     // draw some text!
-    gfx.setCursor(1, 0); // start at top left, with one pixel of spacing
-    gfx.setTextSize(1);  // size 1 == 8 pixels high
-    // gfx.setTextWrap(false); // Don't wrap at end of line - will do ourselves
+    ctx.gfx.setCursor(1, 0); // start at top left, with one pixel of spacing
+    ctx.gfx.setTextSize(1);  // size 1 == 8 pixels high
+    // ctx.gfx.setTextWrap(false); // Don't wrap at end of line - will do ourselves
 
-    gfx.setTextColor(WHITE);
-    gfx.println(" Ada");
-    gfx.println("fruit");
+    ctx.gfx.setTextColor(WHITE);
+    ctx.gfx.println(" Ada");
+    ctx.gfx.println("fruit");
 
     // print each letter with a rainbow color
-    gfx.setTextColor(RED);
-    gfx.print('3');
-    gfx.setTextColor(ORANGE);
-    gfx.print('2');
-    gfx.setTextColor(YELLOW);
-    gfx.print('x');
-    gfx.setTextColor(LIME);
-    gfx.print('3');
-    gfx.setTextColor(GREEN);
-    gfx.println("2");
+    ctx.gfx.setTextColor(RED);
+    ctx.gfx.print('3');
+    ctx.gfx.setTextColor(ORANGE);
+    ctx.gfx.print('2');
+    ctx.gfx.setTextColor(YELLOW);
+    ctx.gfx.print('x');
+    ctx.gfx.setTextColor(LIME);
+    ctx.gfx.print('3');
+    ctx.gfx.setTextColor(GREEN);
+    ctx.gfx.println("2");
 
-    gfx.setTextColor(CYAN);
-    gfx.print('*');
-    gfx.setTextColor(AZURE);
-    gfx.print('R');
-    gfx.setTextColor(BLUE);
-    gfx.print('G');
-    gfx.setTextColor(PURPLE);
-    gfx.print('B');
-    gfx.setTextColor(PINK);
-    gfx.print('*');
+    ctx.gfx.setTextColor(CYAN);
+    ctx.gfx.print('*');
+    ctx.gfx.setTextColor(AZURE);
+    ctx.gfx.print('R');
+    ctx.gfx.setTextColor(BLUE);
+    ctx.gfx.print('G');
+    ctx.gfx.setTextColor(PURPLE);
+    ctx.gfx.print('B');
+    ctx.gfx.setTextColor(PINK);
+    ctx.gfx.print('*');
 
     // whew!
 }
 
-void ExampleScene::loop(Matrix32 &gfx, millis_t dt)
+void ExampleScene::loop(AppContext &ctx, millis_t dt)
 {
     // Do nothing -- image doesn't change
 }

--- a/GRID/ExampleScene.cpp
+++ b/GRID/ExampleScene.cpp
@@ -7,28 +7,28 @@ void ExampleScene::setup(AppContext &ctx)
 {
     // draw a pixel in solid white
     ctx.gfx.drawPixel(0, 0, WHITE);
-    Helpers::sleep(500);
+    ctx.time.sleep(500);
 
     // fix the screen with green
     ctx.gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, GREEN);
-    Helpers::sleep(500);
+    ctx.time.sleep(500);
 
     // draw a box in yellow
     ctx.gfx.drawRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, YELLOW);
-    Helpers::sleep(500);
+    ctx.time.sleep(500);
 
     // draw an 'X' in red
     ctx.gfx.drawLine(0, 0, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 1, RED);
     ctx.gfx.drawLine(MATRIX_WIDTH - 1, 0, 0, MATRIX_HEIGHT - 1, RED);
-    Helpers::sleep(500);
+    ctx.time.sleep(500);
 
     // draw a blue circle
     ctx.gfx.drawCircle(10, 10, 10, BLUE);
-    Helpers::sleep(500);
+    ctx.time.sleep(500);
 
     // fill a violet circle
     ctx.gfx.fillCircle(21, 21, 10, VIOLET);
-    Helpers::sleep(500);
+    ctx.time.sleep(500);
 
     ctx.gfx.clear();
 

--- a/GRID/ExampleScene.h
+++ b/GRID/ExampleScene.h
@@ -9,7 +9,7 @@ class ExampleScene final : public Scene
 {
 public:
     void setup(AppContext &ctx) override;
-    void loop(AppContext &ctx, millis_t dt) override;
+    void loop(AppContext &ctx) override;
 };
 
 #endif

--- a/GRID/ExampleScene.h
+++ b/GRID/ExampleScene.h
@@ -1,14 +1,15 @@
 #ifndef EXAMPLE_SCENE_H
 #define EXAMPLE_SCENE_H
 
+#include "AppContext.h"
 #include "Scene.h"
 #include "helpers.h"
 
 class ExampleScene final : public Scene
 {
 public:
-    void setup(Matrix32 &gfx) override;
-    void loop(Matrix32 &gfx, millis_t dt) override;
+    void setup(AppContext &ctx) override;
+    void loop(AppContext &ctx, millis_t dt) override;
 };
 
 #endif

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -45,7 +45,7 @@ static void smokeTest(Matrix32 &gfx)
 
     // Solid green
     gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, GREEN);
-    delay(2000);
+    Helpers::sleep(2000);
 
     // Alternating rows
     gfx.clear();
@@ -56,7 +56,7 @@ static void smokeTest(Matrix32 &gfx)
             gfx.drawPixel(x, y, (y & 1) ? RED : GREEN);
         }
     }
-    delay(2000);
+    Helpers::sleep(2000);
 
     // Text
     gfx.clear();
@@ -64,13 +64,13 @@ static void smokeTest(Matrix32 &gfx)
     gfx.setTextSize(1);
     gfx.setTextColor(WHITE);
     gfx.println("GRID");
-    delay(1000);
+    Helpers::sleep(1000);
     gfx.setCursor(1, 10);
     gfx.print("<");
-    delay(1000);
+    Helpers::sleep(1000);
     gfx.advance();
     gfx.print(">");
-    delay(1000);
+    Helpers::sleep(1000);
 
     gfx.show();
     gfx.setImmediate(false);

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -23,8 +23,19 @@
 #define D   A3
 #define DB  true
 
-void smokeTest(Matrix32 &gfx)
+// Globals
+
+static RGBmatrixPanel panel(A, B, C, D, CLK, LAT, OE, false);
+static RGBMatrix32 gfx{panel};
+static App app{gfx};
+static unsigned long prev_millis{};
+static unsigned long now_millis{};
+
+// Basic smoke test to verify the display is working
+
+static void smokeTest(Matrix32 &gfx)
 {
+    gfx.setImmediate(true);
     gfx.begin();
 
     // Solid green
@@ -38,7 +49,6 @@ void smokeTest(Matrix32 &gfx)
         for (int x = 0; x < MATRIX_WIDTH; ++x)
         {
             gfx.drawPixel(x, y, (y & 1) ? RED : GREEN);
-            delay(5);
         }
     }
     delay(2000);
@@ -49,17 +59,17 @@ void smokeTest(Matrix32 &gfx)
     gfx.setTextSize(1);
     gfx.setTextColor(WHITE);
     gfx.println("GRID");
+    delay(1000);
     gfx.setCursor(1, 10);
     gfx.print("<");
+    delay(1000);
     gfx.advance();
     gfx.print(">");
-}
+    delay(1000);
 
-static RGBmatrixPanel panel(A, B, C, D, CLK, LAT, OE, false);
-static RGBMatrix32 gfx{panel};
-static App app{gfx};
-static unsigned long prev_millis{};
-static unsigned long now_millis{};
+    gfx.show();
+    gfx.setImmediate(false);
+}
 
 void setup()
 {
@@ -68,14 +78,14 @@ void setup()
     pinMode(0, INPUT_PULLUP);
 
     gfx.begin();
-    // smokeTest();
-    app.setScene<BoidsScene>();
+    smokeTest(gfx);
+    // app.setScene<BoidsScene>();
     prev_millis = millis();
 }
 
 void loop()
 {
     now_millis = millis();
-    app.loopOnce(now_millis - prev_millis);
+//    app.loopOnce(now_millis - prev_millis);
     prev_millis = now_millis;
 }

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -1,6 +1,7 @@
 #include "App.h"
 #include "BoidsScene.h"
 #include "ExampleScene.h"
+#include "helpers.h"
 #include "RGBMatrix32.h"
 #include <RGBmatrixPanel.h>
 
@@ -23,6 +24,8 @@
 #define D   A3
 #define DB  true
 
+using frames_t = uint16_t; // convenience alias for frame counts
+
 // Globals
 
 static RGBmatrixPanel panel(A, B, C, D, CLK, LAT, OE, false);
@@ -30,6 +33,8 @@ static RGBMatrix32 gfx{panel};
 static App app{gfx};
 static unsigned long prev_millis{};
 static unsigned long now_millis{};
+static millis_t fps_last_ms{};
+static uint16_t fps_frames{};
 
 // Basic smoke test to verify the display is working
 
@@ -73,19 +78,32 @@ static void smokeTest(Matrix32 &gfx)
 
 void setup()
 {
-    Serial.begin(9600);
+    Serial.begin(115200);
     randomSeed(analogRead(0));
     pinMode(0, INPUT_PULLUP);
 
     gfx.begin();
-    smokeTest(gfx);
-    // app.setScene<BoidsScene>();
+    // smokeTest(gfx);
+    app.setScene<BoidsScene>();
     prev_millis = millis();
+    fps_last_ms = prev_millis;
 }
 
 void loop()
 {
     now_millis = millis();
-//    app.loopOnce(now_millis - prev_millis);
+    app.loopOnce(now_millis - prev_millis);
     prev_millis = now_millis;
+
+    // FPS counter
+	++fps_frames;
+	millis_t elapsed = now_millis - fps_last_ms;
+	if (elapsed >= 1000) {
+		float fps = (1000.0f * fps_frames) / (float)elapsed;
+		Serial.print("FPS: ");
+		Serial.println(fps, 2); // 2 decimal places
+
+		fps_frames = 0;
+		fps_last_ms = now_millis;
+	}
 }

--- a/GRID/Scene.h
+++ b/GRID/Scene.h
@@ -1,7 +1,7 @@
 #ifndef SCENE_H
 #define SCENE_H
 
-#include "Matrix32.h"
+#include "AppContext.h"
 #include "helpers.h"
 
 /**
@@ -12,9 +12,9 @@ struct Scene
 {
   virtual ~Scene() = default;
   // Called once when the scene is switched to
-  virtual void setup(Matrix32 &gfx) = 0;
+  virtual void setup(AppContext &ctx) = 0;
   // dt is in milliseconds
-  virtual void loop(Matrix32 &gfx, millis_t dt) = 0;
+  virtual void loop(AppContext &cfx, millis_t dt) = 0;
 };
 
 #endif

--- a/GRID/Scene.h
+++ b/GRID/Scene.h
@@ -5,12 +5,22 @@
 #include "helpers.h"
 
 /**
+ * @brief Preferences for scene timing
+ */
+struct SceneTimingPrefs
+{
+  double targetHz;
+};
+
+/**
  * @brief Describes a scene of the game with explicit lifecycle
  *
  */
 struct Scene
 {
   virtual ~Scene() = default;
+  // Return the default FPS
+  virtual SceneTimingPrefs timingPrefs() const { return {60.0}; };
   // Called once when the scene is switched to
   virtual void setup(AppContext &ctx) = 0;
   // dt is in milliseconds

--- a/GRID/Scene.h
+++ b/GRID/Scene.h
@@ -14,7 +14,7 @@ struct Scene
   // Called once when the scene is switched to
   virtual void setup(AppContext &ctx) = 0;
   // dt is in milliseconds
-  virtual void loop(AppContext &cfx, millis_t dt) = 0;
+  virtual void loop(AppContext &cfx) = 0;
 };
 
 #endif

--- a/GRID/Scene.h
+++ b/GRID/Scene.h
@@ -3,14 +3,7 @@
 
 #include "AppContext.h"
 #include "helpers.h"
-
-/**
- * @brief Preferences for scene timing
- */
-struct SceneTimingPrefs
-{
-  double targetHz;
-};
+#include "Timing.h"
 
 /**
  * @brief Describes a scene of the game with explicit lifecycle
@@ -19,8 +12,9 @@ struct SceneTimingPrefs
 struct Scene
 {
   virtual ~Scene() = default;
-  // Return the default FPS
-  virtual SceneTimingPrefs timingPrefs() const { return {60.0}; };
+  // Override to specify a preferred targetHz for the scene
+  // Return NaN to use default (60Hz if not set otherwise)
+  virtual SceneTimingPrefs timingPrefs() const { return {NAN}; };
   // Called once when the scene is switched to
   virtual void setup(AppContext &ctx) = 0;
   // dt is in milliseconds

--- a/GRID/Timing.h
+++ b/GRID/Timing.h
@@ -1,0 +1,21 @@
+#ifndef TIMING_H
+#define TIMING_H
+
+#include "helpers.h"
+
+// Type
+using millis_t = uint32_t; // convenience alias for time in milliseconds
+
+struct Timing
+{
+    virtual ~Timing() = default;
+    virtual millis_t nowMs() const = 0;
+    virtual float dtMs() const = 0;
+    virtual float fps() const = 0;
+    virtual double targetHz() const = 0; // use double for stability & precision
+    virtual void setTargetHz(double hz) = 0;
+    virtual void resetSceneClock() = 0;
+    virtual void delay(millis_t ms) { delay(ms); } // default implementation
+};
+
+#endif // TIMING_H

--- a/GRID/Timing.h
+++ b/GRID/Timing.h
@@ -16,6 +16,7 @@ struct SceneTimingPrefs
 
 struct Timing
 {
+    static constexpr double millisPerSec = 1000.0;
     virtual ~Timing() = default;
     virtual millis_t nowMs() const = 0;
     virtual float dtMs() const = 0;
@@ -24,7 +25,7 @@ struct Timing
     virtual void setTargetHz(double hz) = 0;
     virtual void applyPreference(SceneTimingPrefs pref) = 0;
     virtual void resetSceneClock() = 0;
-    virtual void delay(millis_t ms) { delay(ms); } // default implementation
+    virtual void sleep(millis_t ms) { Helpers::delay(ms); } // default implementation
 };
 
 #endif // TIMING_H

--- a/GRID/Timing.h
+++ b/GRID/Timing.h
@@ -25,7 +25,7 @@ struct Timing
     virtual void setTargetHz(double hz) = 0;
     virtual void applyPreference(SceneTimingPrefs pref) = 0;
     virtual void resetSceneClock() = 0;
-    virtual void sleep(millis_t ms) { Helpers::delay(ms); } // default implementation
+    virtual void sleep(millis_t ms) = 0;
 };
 
 #endif // TIMING_H

--- a/GRID/Timing.h
+++ b/GRID/Timing.h
@@ -6,6 +6,14 @@
 // Type
 using millis_t = uint32_t; // convenience alias for time in milliseconds
 
+/**
+ * @brief Preferences for scene timing
+ */
+struct SceneTimingPrefs
+{
+  double targetHz{NAN};
+};
+
 struct Timing
 {
     virtual ~Timing() = default;
@@ -14,6 +22,7 @@ struct Timing
     virtual float fps() const = 0;
     virtual double targetHz() const = 0; // use double for stability & precision
     virtual void setTargetHz(double hz) = 0;
+    virtual void applyPreference(SceneTimingPrefs pref) = 0;
     virtual void resetSceneClock() = 0;
     virtual void delay(millis_t ms) { delay(ms); } // default implementation
 };

--- a/GRID/helpers.h
+++ b/GRID/helpers.h
@@ -2,30 +2,44 @@
 #define HELPERS_H
 
 #include <cstdint>
+#include <cmath>
 
 // Math
 #define BOUND(l, x, h) ((x) > (h) ? (h) : ((x) < (l) ? (l) : (x))) // return x bounded between l and h
 
+
 // Type 
 using millis_t = uint32_t; // convenience alias for time in milliseconds
+
+namespace Helpers
+{
+    // Provide a random int between 0..range
+    inline int random(int range) { return static_cast<float>(rand()) * range / RAND_MAX; }
+    inline int random() { return rand();}
+}
 
 // Helpers for use by the emulation
 #ifdef GRID_EMULATION
 
 #include <SDL.h>
 
-
 using byte = uint8_t; // Mimic the byte alias in Arduino-land
 
-// Provide a random int between 0..range
-inline int random(int range) { return static_cast<float>(rand()) * range / RAND_MAX; }
-
-// Mimic the Arduino's delay function
-inline void delay(millis_t ms) { SDL_Delay(ms); }
+namespace Helpers
+{
+    // Mimic the Arduino's delay function
+    inline void sleep(uint32_t ms) { SDL_Delay(ms); }
+}
 
 #else
 
 #include <Arduino.h>
+
+namespace Helpers
+{
+    // Mimic the Arduino's delay function
+    inline void sleep(uint32_t ms) { delay(ms); }
+}
 
 #endif // GRID_EMULATION
 #endif // HELPERS_H

--- a/GRID/helpers.h
+++ b/GRID/helpers.h
@@ -28,7 +28,7 @@ using byte = uint8_t; // Mimic the byte alias in Arduino-land
 namespace Helpers
 {
     // Mimic the Arduino's delay function
-    inline void sleep(uint32_t ms) { SDL_Delay(ms); }
+    inline void delay(uint32_t ms) { SDL_Delay(ms); }
 }
 
 #else
@@ -38,7 +38,7 @@ namespace Helpers
 namespace Helpers
 {
     // Mimic the Arduino's delay function
-    inline void sleep(uint32_t ms) { delay(ms); }
+    inline void delay(uint32_t ms) { delay(ms); }
 }
 
 #endif // GRID_EMULATION

--- a/GRID/helpers.h
+++ b/GRID/helpers.h
@@ -25,21 +25,9 @@ namespace Helpers
 
 using byte = uint8_t; // Mimic the byte alias in Arduino-land
 
-namespace Helpers
-{
-    // Mimic the Arduino's delay function
-    inline void delay(uint32_t ms) { SDL_Delay(ms); }
-}
-
 #else
 
 #include <Arduino.h>
-
-namespace Helpers
-{
-    // Mimic the Arduino's delay function
-    inline void delay(uint32_t ms) { delay(ms); }
-}
 
 #endif // GRID_EMULATION
 #endif // HELPERS_H

--- a/emulation/FixedStepTiming.h
+++ b/emulation/FixedStepTiming.h
@@ -8,6 +8,7 @@
 
 class FixedStepTiming final : public Timing
 {
+    const double defaultTargetHz_{ 60.0 };
     double targetHz_;
     double dtSec_;
     double acc_ = 0.0;
@@ -20,7 +21,7 @@ class FixedStepTiming final : public Timing
 
 public:
     explicit FixedStepTiming(double targetHz)
-        : targetHz_(targetHz), dtSec_(1.0 / targetHz)
+        : defaultTargetHz_(targetHz), dtSec_(1.0 / targetHz)
     {
         freq_ = SDL_GetPerformanceFrequency();
         last_ = SDL_GetPerformanceCounter();
@@ -74,6 +75,15 @@ public:
         targetHz_ = BOUND(10.0, hz, 240.0);
         dtSec_ = 1.0 / targetHz_;
         // Optional: smooth retune
+    }
+
+    // When there is a preferred timing, apply it; otherwise use default
+    void applyPreference(SceneTimingPrefs pref) override
+    {
+        if (isnan(pref.targetHz))
+            setTargetHz(defaultTargetHz_);
+        else
+            setTargetHz(pref.targetHz);
     }
 
     void resetSceneClock() override

--- a/emulation/FixedStepTiming.h
+++ b/emulation/FixedStepTiming.h
@@ -93,6 +93,11 @@ public:
         acc_ = 0.0;
         fpsEMA_ = 0.0f;
     }
+
+    void sleep(millis_t ms) override
+    {
+        SDL_Delay(ms);
+    }
 };
 
 #endif // FIXED_STEP_TIMING_H

--- a/emulation/FixedStepTiming.h
+++ b/emulation/FixedStepTiming.h
@@ -5,6 +5,9 @@
 #include <SDL.h>
 #include <algorithm>
 
+/**
+ * @brief A Timing implementation that provides fixed-step timing with cadence control.
+ */
 class FixedStepTiming final : public Timing
 {
     const double defaultTargetHz_{ 60.0 };
@@ -15,7 +18,6 @@ class FixedStepTiming final : public Timing
     uint32_t nowMs_ = 0; // scene clock
     float dtMs_ = 0.0f;
     float fpsEMA_ = 0.0f; // exponential moving average of fps
-    static constexpr double millisPerSec_ = 1000.0;
     static constexpr float k_alpha = 0.2f; // EMA smoothing factor
 
 public:
@@ -42,8 +44,8 @@ public:
         {
             acc_ -= dtSec_;
             ++steps;
-            nowMs_ += static_cast<uint32_t>(dtSec_ * millisPerSec_);
-            dtMs_ = static_cast<float>(dtSec_ * millisPerSec_);
+            nowMs_ += static_cast<uint32_t>(dtSec_ * millisPerSec);
+            dtMs_ = static_cast<float>(dtSec_ * millisPerSec);
         }
         if (steps > 0)
         {
@@ -59,7 +61,7 @@ public:
         if (left > 0.0)
         {
             double sleepSec = std::max(0.0, left - 0.001);
-            SDL_Delay(static_cast<Uint32>(sleepSec * millisPerSec_));
+            sleep(static_cast<Uint32>(sleepSec * millisPerSec));
         }
     }
 

--- a/emulation/FixedStepTiming.h
+++ b/emulation/FixedStepTiming.h
@@ -1,0 +1,87 @@
+#ifndef FIXED_STEP_TIMING_H
+#define FIXED_STEP_TIMING_H
+
+#include "Timing.h"
+#include "helpers.h"
+#include <SDL.h>
+#include <algorithm>
+
+class FixedStepTiming final : public Timing
+{
+    double targetHz_;
+    double dtSec_;
+    double acc_ = 0.0;
+    uint64_t freq_ = 0, last_ = 0;
+    uint32_t nowMs_ = 0; // scene clock
+    float dtMs_ = 0.0f;
+    float fpsEMA_ = 0.0f; // exponential moving average of fps
+    static constexpr double millisPerSec_ = 1000.0;
+    static constexpr float k_alpha = 0.2f; // EMA smoothing factor
+
+public:
+    explicit FixedStepTiming(double targetHz)
+        : targetHz_(targetHz), dtSec_(1.0 / targetHz)
+    {
+        freq_ = SDL_GetPerformanceFrequency();
+        last_ = SDL_GetPerformanceCounter();
+        nowMs_ = SDL_GetTicks();
+    }
+
+    // Advance wall time; return how many fixed steps to run this frame
+    int pump()
+    {
+        uint64_t now = SDL_GetPerformanceCounter();
+        double realDt = double(now - last_) / double(freq_);
+        last_ = now;
+        if (realDt > 0.25)
+            realDt = 0.25; // clamp
+
+        acc_ += realDt;
+        int steps = 0;
+        while (acc_ >= dtSec_ && steps < 5)
+        {
+            acc_ -= dtSec_;
+            ++steps;
+            nowMs_ += static_cast<uint32_t>(dtSec_ * millisPerSec_);
+            dtMs_ = static_cast<float>(dtSec_ * millisPerSec_);
+        }
+        if (steps > 0)
+        {
+            float fpsInst = static_cast<float>(targetHz_);
+            fpsEMA_ = fpsEMA_ <= 0 ? fpsInst : k_alpha * fpsInst + (1 - k_alpha) * fpsEMA_;
+        }
+        return steps;
+    }
+
+    void sleep_to_cadence()
+    {
+        double left = dtSec_ - acc_;
+        if (left > 0.0)
+        {
+            double sleepSec = std::max(0.0, left - 0.001);
+            SDL_Delay(static_cast<Uint32>(sleepSec * millisPerSec_));
+        }
+    }
+
+    // Timing API
+    uint32_t nowMs() const override { return nowMs_; }
+    float dtMs() const override { return dtMs_; }
+    float fps() const override { return fpsEMA_ > 0 ? fpsEMA_ : static_cast<float>(targetHz_); }
+    double targetHz() const override { return targetHz_; }
+
+    void setTargetHz(double hz) override
+    {
+        targetHz_ = BOUND(10.0, hz, 240.0);
+        dtSec_ = 1.0 / targetHz_;
+        // Optional: smooth retune
+    }
+
+    void resetSceneClock() override
+    {
+        nowMs_ = SDL_GetTicks();
+        acc_ = 0.0;
+        fpsEMA_ = 0.0f;
+    }
+};
+
+#endif // FIXED_STEP_TIMING_H

--- a/emulation/FixedStepTiming.h
+++ b/emulation/FixedStepTiming.h
@@ -2,7 +2,6 @@
 #define FIXED_STEP_TIMING_H
 
 #include "Timing.h"
-#include "helpers.h"
 #include <SDL.h>
 #include <algorithm>
 

--- a/emulation/FixedStepTiming.h
+++ b/emulation/FixedStepTiming.h
@@ -22,7 +22,7 @@ class FixedStepTiming final : public Timing
 
 public:
     explicit FixedStepTiming(double targetHz)
-        : defaultTargetHz_(targetHz), dtSec_(1.0 / targetHz)
+        : defaultTargetHz_(targetHz), targetHz_(targetHz), dtSec_(1.0 / targetHz)
     {
         freq_ = SDL_GetPerformanceFrequency();
         last_ = SDL_GetPerformanceCounter();

--- a/emulation/SDLMatrix32.cpp
+++ b/emulation/SDLMatrix32.cpp
@@ -43,7 +43,7 @@ void SDLMatrix32::begin()
     win_ = SDL_CreateWindow("GRID-Emulator", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 320, 320, SDL_WINDOW_RESIZABLE);
     if (!win_)
         throw std::runtime_error(SDL_GetError());
-    ren_ = SDL_CreateRenderer(win_, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    ren_ = SDL_CreateRenderer(win_, -1, SDL_RENDERER_ACCELERATED);
     if (!ren_)
         throw std::runtime_error(SDL_GetError());
     tex_ = SDL_CreateTexture(ren_, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, MATRIX_WIDTH, MATRIX_HEIGHT);

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -21,7 +21,7 @@ void run_emulator()
     App app{gfx, time};
     gfx.begin();
 
-    app.setScene<ExampleScene>();
+    app.setScene<BoidsScene>();
 
     // We pace manually; disable vsync so Present doesn't block unpredictably
     SDL_SetHint(SDL_HINT_RENDER_VSYNC, "0");

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 
 // match GRID hardware
-static constexpr int TICK_HZ = 60;
+static constexpr double TICK_HZ = 16.6; // from hardware measurement
 static constexpr double DT_SEC = 1.0 / TICK_HZ;
 
 static millis_t millis_now(millis_t start) { return SDL_GetTicks() - start; }

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -10,53 +10,44 @@
 // match GRID hardware
 static constexpr double TICK_HZ = 60.0;
 
-void run_emulator()
+void pollEvents(bool &running, SDLMatrix32 &gfx)
 {
-    using u64 = unsigned long long;
+    SDL_Event e;
+    while (SDL_PollEvent(&e))
+    {
+        if (e.type == SDL_QUIT)
+            running = false; // Q triggers quit
+        if (e.type == SDL_KEYDOWN)
+        {
+            if (e.key.keysym.sym == SDLK_ESCAPE || e.key.keysym.sym == SDLK_q)
+                running = false; // ESC also triggers quit
+            else if (e.key.keysym.sym == SDLK_l)
+                gfx.setLEDMode(!gfx.ledMode()); // toggle LED mode when L is pressed
+        }
+    }
+}
+
+// Main emulation loop
+void run_emulation()
+{
     SDLMatrix32 gfx{};
+    gfx.begin();
     FixedStepTiming time{TICK_HZ};
     App app{gfx, time};
-    gfx.begin();
 
-    app.setScene<BoidsScene>();
-
-    // We pace manually; disable vsync so Present doesn't block unpredictably
-    SDL_SetHint(SDL_HINT_RENDER_VSYNC, "0");
+    app.setScene<ExampleScene>();
 
     bool running = true;
-    const u64 freq = SDL_GetPerformanceFrequency();
-    u64 now = SDL_GetPerformanceCounter();
-    double accumulator = 0.0;
     while (running)
     {
         // 1) Events
-        SDL_Event e;
-        while (SDL_PollEvent(&e))
-        {
-            if (e.type == SDL_QUIT)
-                running = false;
-            if (e.type == SDL_KEYDOWN)
-            {
-                if (e.key.keysym.sym == SDLK_ESCAPE || e.key.keysym.sym == SDLK_q)
-                    running = false;
-                else if (e.key.keysym.sym == SDLK_l)
-                    gfx.setLEDMode(!gfx.ledMode());
-            }
-        }
-
-        // 2) Time step accumulation
-        u64 newNow = SDL_GetPerformanceCounter();
-        double frameSec = double(newNow - now) / double(freq);
-        now = newNow;
-
-        // Clamp very large pauses (drag window, breakpoint) to avoid spirals
-        frameSec = std::min(frameSec, 0.25);
-        accumulator += frameSec;
-
+        pollEvents(running, gfx);
+        // 2) Timing
         int steps = time.pump();
-		for (int i = 0; i < steps; ++i) {
-			app.loopOnce(); // Scene consumes ctx.time
-		}
+        for (int i = 0; i < steps; ++i)
+        {
+            app.loopOnce(); // Scene consumes ctx.time
+        }
         gfx.show();
         time.sleep_to_cadence();
     }
@@ -64,6 +55,6 @@ void run_emulator()
 
 int main()
 {
-    run_emulator();
+    run_emulation();
     return 0;
 }

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -9,7 +9,6 @@
 
 // match GRID hardware
 static constexpr double TICK_HZ = 60.0;
-static constexpr double DT_SEC = 1.0 / TICK_HZ;
 
 void run_emulator()
 {

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -11,8 +11,6 @@
 static constexpr double TICK_HZ = 60.0;
 static constexpr double DT_SEC = 1.0 / TICK_HZ;
 
-static millis_t millis_now(millis_t start) { return SDL_GetTicks() - start; }
-
 void run_emulator()
 {
     using u64 = unsigned long long;

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -30,7 +30,6 @@ void run_emulator()
     const u64 freq = SDL_GetPerformanceFrequency();
     u64 now = SDL_GetPerformanceCounter();
     double accumulator = 0.0;
-    millis_t prev_ms = SDL_GetTicks();
     while (running)
     {
         // 1) Events

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -8,7 +8,7 @@
 #include <cstdint>
 
 // match GRID hardware
-static constexpr double TICK_HZ = 16.6; // from hardware measurement
+static constexpr double TICK_HZ = 60.0;
 static constexpr double DT_SEC = 1.0 / TICK_HZ;
 
 static millis_t millis_now(millis_t start) { return SDL_GetTicks() - start; }


### PR DESCRIPTION
# What
Implement a timing component that behaves roughly identically between the GRID hardware and emulation.

## Where
https://www.notion.so/Implement-timing-parity-188e64a563524247a8c96d813c256fb4?v=277f662020b180ba827f000cc9172288&source=copy_link

## Why
GRID runs slower than the emulation, which becomes obvious for the BoidsScene. In experimental measurements BoidsScene ran at ~16 FPS, which pales compared to the faster emulation. So, let's make their timing more consistent with a shared Timing component.

## How?
- :technologist: added a FPS log on Serial for hardware GRID every 1s
- :building_construction: introduce a new AppContext which houses important app components such as graphics (SDL/RGBmatrixPanel state)
- - :electric_plug: wire App to use AppContext
- :sparkles: create shared Timing API for shared timing
- :sparkles: create FixedStepTiming for use in emulation
- :sparkles: create ArduinoPassiveTiming for use in hardware (which interfaces with Arduino lib)
- :electric_plug: wire App to use new timing component
- :recycle: remove redundant code
- :recycle: refactor main runner