### PR TITLE
feat: add inputs component

### DIFF
--- a/GRID/App.h
+++ b/GRID/App.h
@@ -46,6 +46,7 @@ public:
     void loopOnce()
     {
         current->loop(ctx);
+        ctx.gfx.show();
     }
 };
 

--- a/GRID/App.h
+++ b/GRID/App.h
@@ -20,7 +20,7 @@ class App
     std::unique_ptr<Scene> current;
 
 public:
-    explicit App(Matrix32 &gfx, Timing &time) : ctx{gfx, time} {}
+    explicit App(Matrix32 &gfx, Timing &time, Input &input) : ctx{gfx, time, input} {}
 
     // Replace the current scene with a newly constructed SceneT.
     // - Destroys the old scene, creates SceneT(args...), then calls setup(gfx).
@@ -45,6 +45,7 @@ public:
     // dt is in milliseconds.
     void loopOnce()
     {
+        ctx.input.sample();
         current->loop(ctx);
         ctx.gfx.show();
     }

--- a/GRID/AppContext.h
+++ b/GRID/AppContext.h
@@ -3,11 +3,13 @@
 
 #include "Matrix32.h"
 #include "Timing.h"
+#include "Input.h"
 
 struct AppContext
 {
     Matrix32 &gfx; // reference to Matrix 32x32 graphics
     Timing &time;  // reference to timing interface
+    Input &input;  // reference to input interface
 };
 
 #endif // APP_CONTEXT_H

--- a/GRID/ArduinoInputProvider.h
+++ b/GRID/ArduinoInputProvider.h
@@ -16,7 +16,7 @@ public:
     ArduinoInputProvider(uint8_t x, uint8_t y, uint8_t b, const InputCalibration &c = {})
         : IInputProvider(c), pinX(x), pinY(y), pinBtn(b) {}
 
-    void setup() override
+    bool init()
     {
         if (!initialized)
         {
@@ -25,6 +25,7 @@ public:
             pinMode(pinBtn, INPUT_PULLUP); // Button active low
             initialized = true;
         }
+        return initialized;
     }
 
     void sample(InputState &state) override

--- a/GRID/ArduinoInputProvider.h
+++ b/GRID/ArduinoInputProvider.h
@@ -1,0 +1,38 @@
+#ifndef ARDUINO_INPUT_PROVIDER_H
+#define ARDUINO_INPUT_PROVIDER_H
+
+#include "Input.h"
+#include <Arduino.h>
+
+class ArduinoInputProvider final : public IInputProvider
+{
+    // Analog pins for X and Y axes, digital pin for button
+    const uint8_t pinX;
+    const uint8_t pinY;
+    const uint8_t pinBtn;
+    bool initialized = false;
+
+public:
+    ArduinoInputProvider(uint8_t x, uint8_t y, uint8_t b, const InputCalibration &c = {})
+        : IInputProvider(c), pinX(x), pinY(y), pinBtn(b) {}
+
+    void setup() override
+    {
+        if (!initialized)
+        {
+            pinMode(pinX, INPUT);
+            pinMode(pinY, INPUT);
+            pinMode(pinBtn, INPUT_PULLUP); // Button active low
+            initialized = true;
+        }
+    }
+
+    void sample(InputState &state) override
+    {
+        state.x_adc = static_cast<AnalogInput_t>(analogRead(pinX));
+        state.y_adc = static_cast<AnalogInput_t>(analogRead(pinY));
+        state.pressed = (digitalRead(pinBtn) == LOW); // Active low
+    }
+};
+
+#endif // ARDUINO_INPUT_PROVIDER_H

--- a/GRID/ArduinoPassiveTiming.h
+++ b/GRID/ArduinoPassiveTiming.h
@@ -13,10 +13,10 @@
  */
 class ArduinoPassiveTiming final : public Timing
 {
-    const double defaultTargetHz_{ 60.0 };
+    const double defaultTargetHz_{60.0};
     double targetHz_;
     float dtMs_;
-    uint32_t startMs_;
+    millis_t startMs_;
 
 public:
     explicit ArduinoPassiveTiming(double targetHz)
@@ -25,11 +25,11 @@ public:
           startMs_(millis()) {}
 
     // No cadence control; just reflect Arduino time
-    uint32_t nowMs() const override { return millis() - startMs_; }
+    millis_t nowMs() const override { return millis() - startMs_; }
     float dtMs() const override { return dtMs_; } // nominal
     float fps() const override { return static_cast<float>(targetHz_); }
     double targetHz() const override { return targetHz_; }
-    
+
     // When there is a preferred timing, apply it; otherwise use default
     void applyPreference(SceneTimingPrefs pref) override
     {

--- a/GRID/BoidsScene.cpp
+++ b/GRID/BoidsScene.cpp
@@ -58,8 +58,8 @@ void BoidsScene::constrainSpeed(Boid* boid)
  */
 void BoidsScene::constrainPosition(Boid* boid)
 {
-    boid->position.x = BOUND(0, boid->position.x, MATRIX_WIDTH-1);
-    boid->position.y = BOUND(0, boid->position.y, MATRIX_HEIGHT-1);
+    boid->position.x = Helpers::clamp(boid->position.x, 0.0,  double(MATRIX_WIDTH-1));
+    boid->position.y = Helpers::clamp(boid->position.y, 0.0, double(MATRIX_HEIGHT-1));
 }
 
 /*

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -90,7 +90,7 @@ void setup()
     Serial.begin(115200);
     randomSeed(analogRead(0));
     pinMode(0, INPUT_PULLUP);
-    inputProvider.setup();
+    inputProvider.init();
     input.init(&inputProvider);
 
     gfx.begin();
@@ -118,11 +118,15 @@ void loop()
         Serial.println(fps, 2); // 2 decimal places
 
         InputState state = input.state();
-        Serial.print("X: ");
+        Serial.print("Raw ADC X: ");
+        Serial.print(state.x_adc);
+        Serial.print(" Y: ");
+        Serial.print(state.y_adc);
+        Serial.print(", Norm X: ");
         Serial.print(state.x, 2);
         Serial.print(" Y: ");
         Serial.print(state.y, 2);
-        Serial.print(" Pressed: ");
+        Serial.print(", Pressed: ");
         Serial.println(state.pressed);
 
         log_last_ms = now_millis;

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -42,14 +42,13 @@ static uint16_t fps_frames{};
 
 // Basic smoke test to verify the display is working
 
-static void smokeTest(Matrix32 &gfx)
+static void smokeTest(Matrix32 &gfx, Timing &time)
 {
     gfx.setImmediate(true);
-    gfx.begin();
 
     // Solid green
     gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, GREEN);
-    delay(2000);
+    time.sleep(2000);
 
     // Alternating rows
     gfx.clear();
@@ -60,7 +59,7 @@ static void smokeTest(Matrix32 &gfx)
             gfx.drawPixel(x, y, (y & 1) ? RED : GREEN);
         }
     }
-    delay(2000);
+    time.sleep(2000);
 
     // Text
     gfx.clear();
@@ -68,15 +67,14 @@ static void smokeTest(Matrix32 &gfx)
     gfx.setTextSize(1);
     gfx.setTextColor(WHITE);
     gfx.println("GRID");
-    delay(1000);
+    time.sleep(1000);
     gfx.setCursor(1, 10);
     gfx.print("<");
-    delay(1000);
+    time.sleep(1000);
     gfx.advance();
     gfx.print(">");
-    delay(1000);
+    time.sleep(1000);
 
-    gfx.show();
     gfx.setImmediate(false);
 }
 
@@ -87,7 +85,7 @@ void setup()
     pinMode(0, INPUT_PULLUP);
 
     gfx.begin();
-    // smokeTest(gfx);
+    smokeTest(gfx, time); // uncomment to run smoke tests before main app
     app.setScene<BoidsScene>();
     prev_millis = millis();
     fps_last_ms = prev_millis;

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -1,7 +1,8 @@
 #include "App.h"
+#include "ArduinoInputProvider.h"
+#include "ArduinoPassiveTiming.h"
 #include "BoidsScene.h"
 #include "ExampleScene.h"
-#include "ArduinoPassiveTiming.h"
 #include "RGBMatrix32.h"
 #include <RGBmatrixPanel.h>
 
@@ -13,19 +14,23 @@
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
 
-#define CLK  8   // USE THIS ON ADAFRUIT METRO M0, etc.
-//#define CLK A4 // USE THIS ON METRO M4 (not M0)
-//#define CLK 11 // USE THIS ON ARDUINO MEGA
-#define OE   9
+#define CLK 8 // USE THIS ON ADAFRUIT METRO M0, etc.
+// #define CLK A4 // USE THIS ON METRO M4 (not M0)
+// #define CLK 11 // USE THIS ON ARDUINO MEGA
+#define OE 9
 #define LAT 10
-#define A   A0
-#define B   A1
-#define C   A2
-#define D   A3
-#define DB  true
+#define A A0
+#define B A1
+#define C A2
+#define D A3
+#define DB true
 
 // a good target framerate for most scenes
 static constexpr double TICK_HZ = 60.0;
+
+static constexpr uint8_t HORIZONTAL_PIN = A5;
+static constexpr uint8_t VERTICAL_PIN = A4;
+static constexpr uint8_t BUTTON_PIN = 0;
 
 using frames_t = uint16_t; // convenience alias for frame counts
 
@@ -34,10 +39,12 @@ using frames_t = uint16_t; // convenience alias for frame counts
 static RGBmatrixPanel panel(A, B, C, D, CLK, LAT, OE, false);
 static RGBMatrix32 gfx{panel};
 static ArduinoPassiveTiming time{TICK_HZ};
-static App app{gfx, time};
+static ArduinoInputProvider inputProvider{HORIZONTAL_PIN, VERTICAL_PIN, BUTTON_PIN};
+static Input input{};
+static App app{gfx, time, input};
 static unsigned long prev_millis{};
 static unsigned long now_millis{};
-static millis_t fps_last_ms{};
+static millis_t log_last_ms{};
 static uint16_t fps_frames{};
 
 // Basic smoke test to verify the display is working
@@ -83,12 +90,14 @@ void setup()
     Serial.begin(115200);
     randomSeed(analogRead(0));
     pinMode(0, INPUT_PULLUP);
+    inputProvider.setup();
+    input.init(&inputProvider);
 
     gfx.begin();
-    smokeTest(gfx, time); // uncomment to run smoke tests before main app
+    // smokeTest(gfx, time); // uncomment to run smoke tests before main app
     app.setScene<BoidsScene>();
     prev_millis = millis();
-    fps_last_ms = prev_millis;
+    log_last_ms = prev_millis;
 }
 
 void loop()
@@ -100,13 +109,22 @@ void loop()
         prev_millis = now_millis;
     }
 
-    // Log FPS every second
-	millis_t elapsed = now_millis - fps_last_ms;
-	if (elapsed >= time.millisPerSec) {
-		float fps = time.fps();
-		Serial.print("FPS: ");
-		Serial.println(fps, 2); // 2 decimal places
+    // Log every second
+    millis_t elapsed = now_millis - log_last_ms;
+    if (elapsed >= time.millisPerSec)
+    {
+        float fps = time.fps();
+        Serial.print("FPS: ");
+        Serial.println(fps, 2); // 2 decimal places
 
-		fps_last_ms = now_millis;
-	}
+        InputState state = input.state();
+        Serial.print("X: ");
+        Serial.print(state.x, 2);
+        Serial.print(" Y: ");
+        Serial.print(state.y, 2);
+        Serial.print(" Pressed: ");
+        Serial.println(state.pressed);
+
+        log_last_ms = now_millis;
+    }
 }

--- a/GRID/Helpers.h
+++ b/GRID/Helpers.h
@@ -4,15 +4,15 @@
 #include <cstdint>
 #include <cmath>
 
-// Math
-#define BOUND(l, x, h) ((x) > (h) ? (h) : ((x) < (l) ? (l) : (x))) // return x bounded between l and h
-
-
 // Type 
 using millis_t = uint32_t; // convenience alias for time in milliseconds
 
+// These helpers are needed because the defs are missing for either platform
 namespace Helpers
 {
+    // Clamp value v to the range [lo..hi]
+    template <typename T>
+    inline T clamp(T v, T lo, T hi) { return v < lo ? lo : (v > hi ? hi : v); } // Arduino lacks std::clamp
     // Provide a random int between 0..range
     inline int random(int range) { return static_cast<float>(rand()) * range / RAND_MAX; }
     inline int random() { return rand();}

--- a/GRID/Input.cpp
+++ b/GRID/Input.cpp
@@ -1,44 +1,60 @@
 #include "Input.h"
 #include <algorithm>
 
-// Filters
-InputState Input::filterAndClamp(const InputState &s)
+// Normalize 0..1023 to -1..+1
+void Input::normalize(InputState &s)
 {
-    InputState o = s;
-
-    // Normalize 0..1023 to -1..+1
     auto toNorm = [](uint16_t adc)
     {
         return (float(adc) / static_cast<float>(InputState::ADC_MAX)) * 2.0f - 1.0f;
     };
-    o.x = std::clamp(toNorm(s.x_adc), -1.0f, 1.0f);
-    o.y = std::clamp(toNorm(s.y_adc), -1.0f, 1.0f);
+    s.x = std::clamp(toNorm(s.x_adc), -1.0f, 1.0f);
+    s.y = std::clamp(toNorm(s.y_adc), -1.0f, 1.0f);
+}
 
-    // Deadzone to avoid jitter near center
+// Apply eadzone to avoid jitter near center
+void Input::applyDeadzone(InputState &s)
+{
     auto dead = 0.08f;
     auto dz = [&](float v)
     { return (std::fabs(v) < dead) ? 0.0f : v; };
-    o.x = dz(o.x);
-    o.y = dz(o.y);
+    s.x = dz(s.x);
+    s.y = dz(s.y);
+}
 
-    // Curve for finer control near center
+// Apply curve for finer control near center
+void Input::applyCurve(InputState &s)
+{
     auto gamma = 1.8f;
     auto curve = [&](float v)
     {
         float a = std::fabs(v);
         return (v >= 0 ? 1.f : -1.f) * std::pow(a, gamma);
     };
-    o.x = curve(o.x);
-    o.y = curve(o.y);
+    s.x = curve(s.x);
+    s.y = curve(s.y);
+}
 
-    // Recompute ADC in case scenes want integers
+// Recompute ADC in case scenes want integers
+void Input::recomputeADC(InputState &s)
+{
     auto toAdc = [](float v)
     {
         float f = std::clamp((v + 1.0f) * 511.5f, 0.0f, 1023.0f);
         return static_cast<uint16_t>(std::lround(f));
     };
-    o.x_adc = toAdc(o.x);
-    o.y_adc = toAdc(o.y);
+    s.x_adc = toAdc(s.x);
+    s.y_adc = toAdc(s.y);
+}
+
+// Filters
+InputState Input::processInput(const InputState &s)
+{
+    InputState o = s;
+    normalize(o);
+    applyDeadzone(o);
+    applyCurve(o);
+    recomputeADC(o);
 
     return o;
 }

--- a/GRID/Input.cpp
+++ b/GRID/Input.cpp
@@ -1,0 +1,44 @@
+#include "Input.h"
+#include <algorithm>
+
+// Filters
+InputState Input::filterAndClamp(const InputState &s)
+{
+    InputState o = s;
+
+    // Normalize 0..1023 to -1..+1
+    auto toNorm = [](uint16_t adc)
+    {
+        return (float(adc) / static_cast<float>(InputState::ADC_MAX)) * 2.0f - 1.0f;
+    };
+    o.x = std::clamp(toNorm(s.x_adc), -1.0f, 1.0f);
+    o.y = std::clamp(toNorm(s.y_adc), -1.0f, 1.0f);
+
+    // Deadzone to avoid jitter near center
+    auto dead = 0.08f;
+    auto dz = [&](float v)
+    { return (std::fabs(v) < dead) ? 0.0f : v; };
+    o.x = dz(o.x);
+    o.y = dz(o.y);
+
+    // Curve for finer control near center
+    auto gamma = 1.8f;
+    auto curve = [&](float v)
+    {
+        float a = std::fabs(v);
+        return (v >= 0 ? 1.f : -1.f) * std::pow(a, gamma);
+    };
+    o.x = curve(o.x);
+    o.y = curve(o.y);
+
+    // Recompute ADC in case scenes want integers
+    auto toAdc = [](float v)
+    {
+        float f = std::clamp((v + 1.0f) * 511.5f, 0.0f, 1023.0f);
+        return static_cast<uint16_t>(std::lround(f));
+    };
+    o.x_adc = toAdc(o.x);
+    o.y_adc = toAdc(o.y);
+
+    return o;
+}

--- a/GRID/Input.cpp
+++ b/GRID/Input.cpp
@@ -1,4 +1,6 @@
 #include "Input.h"
+#include "Helpers.h"
+#include <cmath>
 #include <algorithm>
 
 // Normalize 0..1023 to -1..+1
@@ -8,11 +10,11 @@ void Input::normalize(InputState &s)
     {
         return (float(adc) / static_cast<float>(InputState::ADC_MAX)) * 2.0f - 1.0f;
     };
-    s.x = std::clamp(toNorm(s.x_adc), -1.0f, 1.0f);
-    s.y = std::clamp(toNorm(s.y_adc), -1.0f, 1.0f);
+    s.x = Helpers::clamp(toNorm(s.x_adc), -1.0f, 1.0f);
+    s.y = Helpers::clamp(toNorm(s.y_adc), -1.0f, 1.0f);
 }
 
-// Apply eadzone to avoid jitter near center
+// Apply deadzone to avoid jitter near center
 void Input::applyDeadzone(InputState &s)
 {
     auto dead = 0.08f;
@@ -40,7 +42,7 @@ void Input::recomputeADC(InputState &s)
 {
     auto toAdc = [](float v)
     {
-        float f = std::clamp((v + 1.0f) * 511.5f, 0.0f, 1023.0f);
+        float f = Helpers::clamp((v + 1.0f) * 511.5f, 0.0f, 1023.0f);
         return static_cast<uint16_t>(std::lround(f));
     };
     s.x_adc = toAdc(s.x);

--- a/GRID/Input.cpp
+++ b/GRID/Input.cpp
@@ -49,7 +49,8 @@ void Input::recomputeADC(InputState &s)
     s.y_adc = toAdc(s.y);
 }
 
-// Filters
+// Deadzone: treat small magnitudes as 0 to kill drift.
+// Response curve: v' = sign(v) * |v|^γ for finer low‑end control.
 InputState Input::processInput(const InputState &s)
 {
     InputState o = s;

--- a/GRID/Input.h
+++ b/GRID/Input.h
@@ -32,7 +32,6 @@ class IInputProvider
 
 public:
     IInputProvider(const InputCalibration &c) : calib(c) {}
-    virtual void setup() = 0;
     virtual ~IInputProvider() = default;
     // Called once per tick; must be non-blocking
     virtual void sample(InputState &out) = 0;

--- a/GRID/Input.h
+++ b/GRID/Input.h
@@ -3,6 +3,9 @@
 
 #include <cstdint>
 
+using AnalogInput_t = uint16_t;
+using DigitalInput_t = bool;
+
 struct InputCalibration
 {
     const float deadzone = 0.08f; // 0..1
@@ -14,9 +17,9 @@ struct InputState
     constexpr static int ADC_MAX = 1023;
 
     // Raw Arduino-like
-    uint16_t x_adc; // 0..1023
-    uint16_t y_adc; // 0..1023
-    bool pressed;
+    AnalogInput_t x_adc; // 0..1023
+    AnalogInput_t y_adc; // 0..1023
+    DigitalInput_t pressed;
 
     // Normalized helpers
     float x; // -1..+1
@@ -25,7 +28,6 @@ struct InputState
 
 class IInputProvider
 {
-    bool initialized = false;
     InputCalibration calib;
 
 public:

--- a/GRID/Input.h
+++ b/GRID/Input.h
@@ -28,9 +28,8 @@ struct InputState
 
 class IInputProvider
 {
-    InputCalibration calib;
-
 public:
+    const InputCalibration calib;
     IInputProvider(const InputCalibration &c) : calib(c) {}
     virtual ~IInputProvider() = default;
     // Called once per tick; must be non-blocking

--- a/GRID/Input.h
+++ b/GRID/Input.h
@@ -1,0 +1,50 @@
+#ifndef INPUT_H
+#define INPUT_H
+
+#include <cstdint>
+
+struct InputState
+{
+    constexpr static int ADC_MAX = 1023;
+
+    // Raw Arduino-like
+    uint16_t x_adc; // 0..1023
+    uint16_t y_adc; // 0..1023
+    bool pressed;
+
+    // Normalized helpers
+    float x; // -1..+1
+    float y; // -1..+1
+};
+
+class IInputProvider
+{
+public:
+    virtual ~IInputProvider() = default;
+    // Called once per tick; must be non-blocking
+    virtual void sample(InputState &out) = 0;
+};
+
+class Input
+{
+public:
+    void init(IInputProvider *provider) { prov = provider; }
+    // Call at start of each tick
+    void sample()
+    {
+        InputState raw;
+        prov->sample(raw);
+        current = filterAndClamp(raw);
+        frameId++;
+    }
+    const InputState &state() const { return current; }
+    uint64_t frame() const { return frameId; }
+
+private:
+    IInputProvider *prov = nullptr;
+    InputState current{};
+    uint64_t frameId = 0;
+    InputState filterAndClamp(const InputState &s);
+};
+
+#endif // INPUT_H

--- a/emulation/FixedStepTiming.h
+++ b/emulation/FixedStepTiming.h
@@ -73,7 +73,7 @@ public:
 
     void setTargetHz(double hz) override
     {
-        targetHz_ = BOUND(10.0, hz, 240.0);
+        targetHz_ = Helpers::clamp(hz, 10.0, 240.0);
         dtSec_ = 1.0 / targetHz_;
         // Optional: smooth retune
     }

--- a/emulation/SDLInputProvider.cpp
+++ b/emulation/SDLInputProvider.cpp
@@ -63,6 +63,62 @@ void SDLInputProvider::setMouseRelative(bool enabled)
     SDL_SetWindowGrab(window, enabled ? SDL_TRUE : SDL_FALSE);
 }
 
+void SDLInputProvider::handleKeyDown(const SDL_KeyboardEvent &key)
+{
+    const SDL_Keycode k = key.keysym.sym;
+    if (k == SDLK_q || k == SDLK_ESCAPE)
+    {
+        if (quitCb)
+            quitCb();
+    }
+    else if (k == SDLK_l)
+    {
+        if (toggleLEDCb)
+            toggleLEDCb();
+    }
+}
+
+void SDLInputProvider::handleWindowEvent(const SDL_WindowEvent &we)
+{
+    if (we.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+    {
+        windowFocused = true;
+        // Recenter analog accumulator on focus gain
+        vx = vy = 0.f;
+        SDL_GetRelativeMouseState(nullptr, nullptr); // flush delta
+    }
+    else if (we.event == SDL_WINDOWEVENT_FOCUS_LOST)
+    {
+        windowFocused = false;
+        lmbHeld = rmbHeld = false;
+        vx = vy = 0.f;
+    }
+}
+
+void SDLInputProvider::handleMouseButtonDown(const SDL_MouseButtonEvent &be)
+{
+    if (be.button == SDL_BUTTON_LEFT)
+    {
+        lmbHeld = true;
+    }
+    if (be.button == SDL_BUTTON_RIGHT)
+    {
+        rmbHeld = true;
+    }
+}
+
+void SDLInputProvider::handleMouseButtonUp(const SDL_MouseButtonEvent &be)
+{
+    if (be.button == SDL_BUTTON_LEFT)
+    {
+        lmbHeld = false;
+    }
+    if (be.button == SDL_BUTTON_RIGHT)
+    {
+        rmbHeld = false;
+    }
+}
+
 void SDLInputProvider::pumpEvents()
 {
     SDL_Event e;
@@ -79,42 +135,13 @@ void SDLInputProvider::pumpEvents()
         case SDL_KEYDOWN:
         {
             const SDL_Keycode k = e.key.keysym.sym;
-            if (k == SDLK_q || k == SDLK_ESCAPE)
-            {
-                if (quitCb)
-                    quitCb();
-            }
-            else if (k == SDLK_l)
-            {
-                if (toggleLEDCb)
-                    toggleLEDCb();
-            }
-            else if (k == SDLK_F1)
-            {
-                mode = (mode == InputMode::DPad) ? InputMode::Analog : InputMode::DPad;
-                if (mode == InputMode::Analog)
-                {
-                    vx = vy = 0.f;
-                    SDL_GetRelativeMouseState(nullptr, nullptr);
-                }
-            }
+            handleKeyDown(e.key);
             break;
         }
         case SDL_WINDOWEVENT:
         {
-            if (e.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
-            {
-                windowFocused = true;
-                // Recenter analog accumulator on focus gain
-                vx = vy = 0.f;
-                SDL_GetRelativeMouseState(nullptr, nullptr); // flush delta
-            }
-            else if (e.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
-            {
-                windowFocused = false;
-                lmbHeld = rmbHeld = false;
-                vx = vy = 0.f;
-            }
+            const SDL_WindowEvent &we = e.window;
+            handleWindowEvent(we);
             break;
         }
         case SDL_CONTROLLERDEVICEADDED:
@@ -137,26 +164,14 @@ void SDLInputProvider::pumpEvents()
         }
         case SDL_MOUSEBUTTONDOWN:
         {
-            if (e.button.button == SDL_BUTTON_LEFT)
-            {
-                lmbHeld = true;
-            }
-            if (e.button.button == SDL_BUTTON_RIGHT)
-            {
-                rmbHeld = true;
-            }
+            const SDL_MouseButtonEvent &be = e.button;
+            handleMouseButtonDown(be);
             break;
         }
         case SDL_MOUSEBUTTONUP:
         {
-            if (e.button.button == SDL_BUTTON_LEFT)
-            {
-                lmbHeld = false;
-            }
-            if (e.button.button == SDL_BUTTON_RIGHT)
-            {
-                rmbHeld = false;
-            }
+            const SDL_MouseButtonEvent &be = e.button;
+            handleMouseButtonUp(be);
             break;
         }
         default:
@@ -195,6 +210,21 @@ void SDLInputProvider::sample(InputState &state)
     }
 }
 
+void SDLInputProvider::normalizeToUnitCircle(float &x, float &y)
+{
+    float mag = std::sqrt(x * x + y * y);
+    if (mag > EPSILON)
+    {
+        x /= mag;
+        y /= mag;
+    }
+    else
+    {
+        x = 0.f;
+        y = 0.f;
+    }
+}
+
 void SDLInputProvider::genDPad(InputState &s)
 {
     // Keyboard D-pad only. Ignore ramping for now.
@@ -210,12 +240,7 @@ void SDLInputProvider::genDPad(InputState &s)
 
     // Normalize to unit circle for diagonals
     float fx = float(x), fy = float(y);
-    float mag = std::sqrt(fx * fx + fy * fy);
-    if (mag > EPSILON)
-    {
-        fx /= mag;
-        fy /= mag;
-    }
+    normalizeToUnitCircle(fx, fy);
 
     if (invertY)
         fy = -fy;
@@ -227,6 +252,48 @@ void SDLInputProvider::genDPad(InputState &s)
     s.y_adc = toADCFromNorm(s.y);
 }
 
+void SDLInputProvider::useSDLAxis(float &x, float &y, bool &haveAnalog)
+{
+    if (pad)
+    {
+        // SDL axes are -32768..32767
+        const float k = 1.0f / 32767.0f;
+        Sint16 ax = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTX);
+        Sint16 ay = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTY);
+        x = Helpers::clamp(ax * k, -1.f, 1.f);
+        y = Helpers::clamp(ay * k, -1.f, 1.f);
+        haveAnalog = std::fabs(x) > EPSILON || std::fabs(y) > EPSILON;
+    }
+}
+
+void SDLInputProvider::useMouseDeltas(float &nx, float &ny, bool &haveAnalog)
+{
+    int dx = 0, dy = 0;
+
+    // Only accumulate relative motion when LMB is held
+    if (lmbHeld)
+    {
+        SDL_GetRelativeMouseState(&dx, &dy);
+        const float kSens = 0.015f;
+        const float decay = 0.12f;
+        vx += kSens * float(dx);
+        vy += kSens * float(dy);
+        // when LMB is down, you can keep weaker decay or none; keep gentle default:
+        vx *= (1.f - decay);
+        vy *= (1.f - decay);
+    }
+    else
+    {
+        // If LMB not held, decay aggressively toward 0 so we quickly “let go”
+        vx *= 0.5f;
+        vy *= 0.5f;
+    }
+
+    nx = Helpers::clamp(vx, -1.f, 1.f);
+    ny = Helpers::clamp(vy, -1.f, 1.f);
+    haveAnalog = std::fabs(nx) > EPSILON || std::fabs(ny) > EPSILON;
+}
+
 void SDLInputProvider::genAnalog(InputState &s)
 {
     // 1) Try gamepad left stick if present
@@ -234,43 +301,12 @@ void SDLInputProvider::genAnalog(InputState &s)
     float nx = 0.f, ny = 0.f;
 
     if (pad)
-    {
-        // SDL axes are -32768..32767
-        const float k = 1.0f / 32767.0f;
-        Sint16 ax = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTX);
-        Sint16 ay = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTY);
-        nx = Helpers::clamp(ax * k, -1.f, 1.f);
-        ny = Helpers::clamp(ay * k, -1.f, 1.f);
-        haveAnalog = std::fabs(nx) > 0.001f || std::fabs(ny) > 0.001f;
-    }
+        useSDLAxis(nx, ny, haveAnalog);
 
     // 2) If no gamepad analog, use mouse relative deltas (velocity model)
     if (!haveAnalog && windowFocused)
     {
-        int dx = 0, dy = 0;
-
-        // Only accumulate relative motion when LMB is held
-        if (lmbHeld)
-        {
-            SDL_GetRelativeMouseState(&dx, &dy);
-            const float kSens = 0.015f;
-            const float decay = 0.12f;
-            vx += kSens * float(dx);
-            vy += kSens * float(dy);
-            // when LMB is down, you can keep weaker decay or none; keep gentle default:
-            vx *= (1.f - decay);
-            vy *= (1.f - decay);
-        }
-        else
-        {
-            // If LMB not held, decay aggressively toward 0 so we quickly “let go”
-            vx *= 0.5f;
-            vy *= 0.5f;
-        }
-
-        nx = Helpers::clamp(vx, -1.f, 1.f);
-        ny = Helpers::clamp(vy, -1.f, 1.f);
-        haveAnalog = std::fabs(nx) > 0.001f || std::fabs(ny) > 0.001f;
+        useMouseDeltas(nx, ny, haveAnalog);
     }
 
     // 3) If neither provides signal, fall back to keyboard D‑pad
@@ -280,21 +316,7 @@ void SDLInputProvider::genAnalog(InputState &s)
         return;
     }
 
-    // Deadzone and curve using example defaults
-    const float dead = 0.08f;
-    auto dz = [&](float v)
-    { return (std::fabs(v) < dead) ? 0.f : v; };
-    nx = dz(nx);
-    ny = dz(ny);
-
-    const float gamma = 1.8f;
-    auto curve = [&](float v)
-    {
-        const float a = std::fabs(v);
-        return (v >= 0.f ? 1.f : -1.f) * std::pow(a, gamma);
-    };
-    nx = curve(nx);
-    ny = curve(ny);
+    normalizeToUnitCircle(nx, ny);
 
     if (invertY)
         ny = -ny;

--- a/emulation/SDLInputProvider.cpp
+++ b/emulation/SDLInputProvider.cpp
@@ -70,7 +70,38 @@ void SDLInputProvider::pumpEvents()
     {
         switch (e.type)
         {
+        case SDL_QUIT:
+        {
+            if (quitCb)
+                quitCb();
+            break;
+        }
+        case SDL_KEYDOWN:
+        {
+            const SDL_Keycode k = e.key.keysym.sym;
+            if (k == SDLK_q || k == SDLK_ESCAPE)
+            {
+                if (quitCb)
+                    quitCb();
+            }
+            else if (k == SDLK_l)
+            {
+                if (toggleLEDCb)
+                    toggleLEDCb();
+            }
+            else if (k == SDLK_F1)
+            {
+                mode = (mode == InputMode::DPad) ? InputMode::Analog : InputMode::DPad;
+                if (mode == InputMode::Analog)
+                {
+                    vx = vy = 0.f;
+                    SDL_GetRelativeMouseState(nullptr, nullptr);
+                }
+            }
+            break;
+        }
         case SDL_WINDOWEVENT:
+        {
             if (e.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
             {
                 windowFocused = true;
@@ -85,11 +116,15 @@ void SDLInputProvider::pumpEvents()
                 vx = vy = 0.f;
             }
             break;
+        }
         case SDL_CONTROLLERDEVICEADDED:
+        {
             if (!pad)
                 openFirstController();
             break;
+        }
         case SDL_CONTROLLERDEVICEREMOVED:
+        {
             if (pad)
             {
                 SDL_Joystick *js = SDL_GameControllerGetJoystick(pad);
@@ -99,20 +134,9 @@ void SDLInputProvider::pumpEvents()
                 }
             }
             break;
-        case SDL_KEYDOWN:
-            // Example: toggle mode with F1
-            if (e.key.keysym.sym == SDLK_F1)
-            {
-                mode = (mode == InputMode::DPad) ? InputMode::Analog : InputMode::DPad;
-                // Reset accumulators when switching into Analog
-                if (mode == InputMode::Analog)
-                {
-                    vx = vy = 0.f;
-                    SDL_GetRelativeMouseState(nullptr, nullptr);
-                }
-            }
-            break;
+        }
         case SDL_MOUSEBUTTONDOWN:
+        {
             if (e.button.button == SDL_BUTTON_LEFT)
             {
                 lmbHeld = true;
@@ -122,7 +146,9 @@ void SDLInputProvider::pumpEvents()
                 rmbHeld = true;
             }
             break;
+        }
         case SDL_MOUSEBUTTONUP:
+        {
             if (e.button.button == SDL_BUTTON_LEFT)
             {
                 lmbHeld = false;
@@ -132,6 +158,7 @@ void SDLInputProvider::pumpEvents()
                 rmbHeld = false;
             }
             break;
+        }
         default:
             break;
         }
@@ -163,7 +190,7 @@ void SDLInputProvider::sample(InputState &state)
             vx = vy = 0.f; // reset mouse accumulator on exit
         }
         // In D-pad, button is Space (you can also keep RMB if desired)
-        state.pressed = (kb[SDL_SCANCODE_SPACE] != 0);
+        state.pressed = (kb && kb[SDL_SCANCODE_SPACE] != 0);
         genDPad(state);
     }
 }

--- a/emulation/SDLInputProvider.cpp
+++ b/emulation/SDLInputProvider.cpp
@@ -1,0 +1,231 @@
+// SDLInputProvider.cpp
+#include "SDLInputProvider.h"
+#include "Helpers.h"
+
+constexpr float EPSILON = 1e-6f;
+
+bool SDLInputProvider::init(SDL_Window *win)
+{
+    if (initialized)
+        return false; // already initialized
+
+    window = win;
+    kb = SDL_GetKeyboardState(nullptr);
+
+    // Prefer gamepad if available
+    SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER);
+    openFirstController();
+
+    // Mouse relative + grab as requested
+    setMouseRelative(true);
+
+    return true;
+}
+
+void SDLInputProvider::shutdown()
+{
+    closeController();
+    setMouseRelative(false);
+}
+
+void SDLInputProvider::openFirstController()
+{
+    if (pad)
+        return;
+    for (int i = 0; i < SDL_NumJoysticks(); ++i)
+    {
+        if (SDL_IsGameController(i))
+        {
+            pad = SDL_GameControllerOpen(i);
+            if (pad)
+                break;
+        }
+    }
+}
+
+void SDLInputProvider::closeController()
+{
+    if (pad)
+    {
+        SDL_GameControllerClose(pad);
+        pad = nullptr;
+    }
+}
+
+void SDLInputProvider::setMouseRelative(bool enabled)
+{
+    SDL_SetRelativeMouseMode(enabled ? SDL_TRUE : SDL_FALSE);
+    SDL_SetWindowGrab(window, enabled ? SDL_TRUE : SDL_FALSE);
+}
+
+void SDLInputProvider::pumpEvents()
+{
+    SDL_Event e;
+    while (SDL_PollEvent(&e))
+    {
+        switch (e.type)
+        {
+        case SDL_WINDOWEVENT:
+            if (e.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+            {
+                windowFocused = true;
+                // Recenter analog accumulator on focus gain
+                vx = vy = 0.f;
+                SDL_GetRelativeMouseState(nullptr, nullptr); // flush delta
+            }
+            else if (e.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+            {
+                windowFocused = false;
+                vx = vy = 0.f;
+            }
+            break;
+        case SDL_CONTROLLERDEVICEADDED:
+            if (!pad)
+                openFirstController(); // auto-open
+            break;
+        case SDL_CONTROLLERDEVICEREMOVED:
+            if (pad && e.cdevice.which == SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(pad)))
+            {
+                closeController();
+            }
+            break;
+        case SDL_KEYDOWN:
+            // Example: toggle mode with F1
+            if (e.key.keysym.sym == SDLK_F1)
+            {
+                mode = (mode == InputMode::DPad) ? InputMode::Analog : InputMode::DPad;
+                // Reset accumulators when switching into Analog
+                if (mode == InputMode::Analog)
+                {
+                    vx = vy = 0.f;
+                    SDL_GetRelativeMouseState(nullptr, nullptr);
+                }
+            }
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+void SDLInputProvider::sample(InputState &state)
+{
+    // Button mapping (Space) always available
+    state.pressed = kb[SDL_SCANCODE_SPACE];
+
+    // Fallback order: gamepad → mouse → keyboard
+    if (mode == InputMode::Analog)
+    {
+        genAnalog(state);
+    }
+    else
+    {
+        genDPad(state);
+    }
+}
+
+void SDLInputProvider::genDPad(InputState &s)
+{
+    // Keyboard D-pad only. Ignore ramping for now.
+    int x = 0, y = 0;
+    if (kb[SDL_SCANCODE_A] || kb[SDL_SCANCODE_LEFT])
+        x -= 1;
+    if (kb[SDL_SCANCODE_D] || kb[SDL_SCANCODE_RIGHT])
+        x += 1;
+    if (kb[SDL_SCANCODE_W] || kb[SDL_SCANCODE_UP])
+        y -= 1;
+    if (kb[SDL_SCANCODE_S] || kb[SDL_SCANCODE_DOWN])
+        y += 1;
+
+    // Normalize to unit circle for diagonals
+    float fx = float(x), fy = float(y);
+    float mag = std::sqrt(fx * fx + fy * fy);
+    if (mag > EPSILON)
+    {
+        fx /= mag;
+        fy /= mag;
+    }
+
+    if (invertY)
+        fy = -fy;
+
+    // Snap to full deflection in ADC space (0 or 1023)
+    s.x = fx;
+    s.y = fy;
+    s.x_adc = toADCFromNorm(s.x);
+    s.y_adc = toADCFromNorm(s.y);
+}
+
+void SDLInputProvider::genAnalog(InputState &s)
+{
+    // 1) Try gamepad left stick if present
+    bool haveAnalog = false;
+    float nx = 0.f, ny = 0.f;
+
+    if (pad)
+    {
+        // SDL axes are -32768..32767
+        const float k = 1.0f / 32767.0f;
+        Sint16 ax = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTX);
+        Sint16 ay = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTY);
+        nx = Helpers::clamp(ax * k, -1.f, 1.f);
+        ny = Helpers::clamp(ay * k, -1.f, 1.f);
+        haveAnalog = std::fabs(nx) > 0.001f || std::fabs(ny) > 0.001f;
+    }
+
+    // 2) If no gamepad analog, use mouse relative deltas (velocity model)
+    if (!haveAnalog && windowFocused)
+    {
+        int dx, dy;
+        Uint32 buttons = SDL_GetRelativeMouseState(&dx, &dy);
+        (void)buttons; // button mapped from Space per your spec
+
+        // Sensitivity/decay: you asked to ignore for now; use gentle defaults
+        // k: px → norm, decay λ at 60 Hz
+        const float kSens = 0.015f;
+        const float decay = 0.12f;
+
+        vx += kSens * float(dx);
+        vy += kSens * float(dy);
+
+        // Decay to re-center when mouse stops
+        vx *= (1.f - decay);
+        vy *= (1.f - decay);
+
+        // Clamp to [-1,1]
+        nx = Helpers::clamp(vx, -1.f, 1.f);
+        ny = Helpers::clamp(vy, -1.f, 1.f);
+        haveAnalog = std::fabs(nx) > 0.001f || std::fabs(ny) > 0.001f;
+    }
+
+    // 3) If neither provides signal, fall back to keyboard D‑pad
+    if (!haveAnalog)
+    {
+        genDPad(s);
+        return;
+    }
+
+    // Deadzone and curve using example defaults
+    const float dead = 0.08f;
+    auto dz = [&](float v)
+    { return (std::fabs(v) < dead) ? 0.f : v; };
+    nx = dz(nx);
+    ny = dz(ny);
+
+    const float gamma = 1.8f;
+    auto curve = [&](float v)
+    {
+        const float a = std::fabs(v);
+        return (v >= 0.f ? 1.f : -1.f) * std::pow(a, gamma);
+    };
+    nx = curve(nx);
+    ny = curve(ny);
+
+    if (invertY)
+        ny = -ny;
+
+    s.x = Helpers::clamp(nx, -1.f, 1.f);
+    s.y = Helpers::clamp(ny, -1.f, 1.f);
+    s.x_adc = toADCFromNorm(s.x);
+    s.y_adc = toADCFromNorm(s.y);
+}

--- a/emulation/SDLInputProvider.h
+++ b/emulation/SDLInputProvider.h
@@ -14,30 +14,21 @@ enum class InputMode
 
 class SDLInputProvider final : public IInputProvider
 {
-    bool initialized = false;
-
-public:
-    SDLInputProvider(const InputCalibration &c = {}) : IInputProvider(c) {}
-    bool init(SDL_Window *win);
-    void shutdown();
-    ~SDLInputProvider() override { shutdown(); }
-
-    // Call once per frame at 60 Hz
-    void pumpEvents();              // SDL_PollEvent loop, handle focus/mode/buttons, etc.
-    void sample(InputState &state); // fills state based on current mode and devices
-
-    // Optional: toggle mode externally
-    void setMode(InputMode m) { mode = m; }
-    InputMode getMode() const { return mode; }
-
-private:
     // State
+
+    bool initialized = false;
+    millis_t lastAnalogActiveMs = 0;          // time of last analog engagement
+    const millis_t analogIdleTimeoutMs = 250; // revert to D-pad after this idle window
+    bool lmbHeld = false;
+    bool rmbHeld = false;
+
     SDL_Window *window = nullptr;
     SDL_GameController *pad = nullptr;
     bool windowFocused = true;
 
     // Config
-    InputMode mode = InputMode::DPad; // default
+
+    InputMode mode = InputMode::DPad; // whether to use D-pad or analog mode
     bool invertY = false;
 
     // Keyboard state cache
@@ -55,6 +46,21 @@ private:
     void genDPad(InputState &s);
     void genAnalog(InputState &s);
 
+public:
+    SDLInputProvider(const InputCalibration &c = {}) : IInputProvider(c) {}
+    bool init(SDL_Window *win);
+    void shutdown();
+    ~SDLInputProvider() override { shutdown(); }
+
+    // Call once per frame at 60 Hz
+    void pumpEvents();                       // SDL_PollEvent loop, handle focus/mode/buttons, etc.
+    void sample(InputState &state) override; // fills state based on current mode and devices
+
+    // Optional: toggle mode externally
+    void setMode(InputMode m) { mode = m; }
+    InputMode getMode() const { return mode; }
+
+private:
     // Utilities
     static inline float toNormFromADC(AnalogInput_t adc)
     {
@@ -64,6 +70,16 @@ private:
     {
         const float f = Helpers::clamp((v + 1.f) * (InputState::ADC_MAX / 2.f), 0.f, float(InputState::ADC_MAX));
         return static_cast<AnalogInput_t>(lroundf(f));
+    }
+    // Check if left stick is moved beyond a small threshold
+    static inline bool stickActive(SDL_GameController *pad, float thresh = 0.02f)
+    {
+        if (!pad)
+            return false;
+        const float k = 1.0f / 32767.0f;
+        float ax = std::abs(SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTX) * k);
+        float ay = std::abs(SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTY) * k);
+        return (ax > thresh) || (ay > thresh);
     }
 };
 

--- a/emulation/SDLInputProvider.h
+++ b/emulation/SDLInputProvider.h
@@ -1,0 +1,70 @@
+#ifndef SDL_INPUT_PROVIDER_H
+#define SDL_INPUT_PROVIDER_H
+
+// SDLInputProvider.h
+#include "Input.h"
+#include "Helpers.h"
+#include <SDL.h>
+
+enum class InputMode
+{
+    DPad,
+    Analog
+};
+
+class SDLInputProvider final : public IInputProvider
+{
+    bool initialized = false;
+
+public:
+    SDLInputProvider(const InputCalibration &c = {}) : IInputProvider(c) {}
+    bool init(SDL_Window *win);
+    void shutdown();
+    ~SDLInputProvider() override { shutdown(); }
+
+    // Call once per frame at 60 Hz
+    void pumpEvents();              // SDL_PollEvent loop, handle focus/mode/buttons, etc.
+    void sample(InputState &state); // fills state based on current mode and devices
+
+    // Optional: toggle mode externally
+    void setMode(InputMode m) { mode = m; }
+    InputMode getMode() const { return mode; }
+
+private:
+    // State
+    SDL_Window *window = nullptr;
+    SDL_GameController *pad = nullptr;
+    bool windowFocused = true;
+
+    // Config
+    InputMode mode = InputMode::DPad; // default
+    bool invertY = false;
+
+    // Keyboard state cache
+    const uint8_t *kb = nullptr;
+
+    // Mouse analog accumulator (velocity model)
+    float vx = 0.f, vy = 0.f;
+
+    // Helpers
+    void openFirstController();
+    void closeController();
+    void setMouseRelative(bool enabled);
+
+    // Generators
+    void genDPad(InputState &s);
+    void genAnalog(InputState &s);
+
+    // Utilities
+    static inline float toNormFromADC(AnalogInput_t adc)
+    {
+        return ((float(adc) / float(InputState::ADC_MAX)) * 2.f) - 1.f;
+    }
+    static inline AnalogInput_t toADCFromNorm(float v)
+    {
+        const float f = Helpers::clamp((v + 1.f) * (InputState::ADC_MAX / 2.f), 0.f, float(InputState::ADC_MAX));
+        return static_cast<AnalogInput_t>(lroundf(f));
+    }
+};
+
+#endif // SDL_INPUT_PROVIDER_H

--- a/emulation/SDLInputProvider.h
+++ b/emulation/SDLInputProvider.h
@@ -5,6 +5,7 @@
 #include "Input.h"
 #include "Helpers.h"
 #include <SDL.h>
+#include <functional>
 
 enum class InputMode
 {
@@ -25,6 +26,10 @@ class SDLInputProvider final : public IInputProvider
     SDL_Window *window = nullptr;
     SDL_GameController *pad = nullptr;
     bool windowFocused = true;
+
+    // Callbacks
+    std::function<void()> quitCb;      // Q or Esc
+    std::function<void()> toggleLEDCb; // L
 
     // Config
 
@@ -52,9 +57,15 @@ public:
     void shutdown();
     ~SDLInputProvider() override { shutdown(); }
 
-    // Call once per frame at 60 Hz
-    void pumpEvents();                       // SDL_PollEvent loop, handle focus/mode/buttons, etc.
-    void sample(InputState &state) override; // fills state based on current mode and devices
+    // Single SDL_PollEvent loop, handle focus/mode/buttons, etc.
+    void pumpEvents();
+
+    // Hooks
+    void onQuit(std::function<void()> cb) { quitCb = std::move(cb); }
+    void onToggleLED(std::function<void()> cb) { toggleLEDCb = std::move(cb); }
+
+    // fills state based on current mode and devices
+    void sample(InputState &state) override;
 
     // Optional: toggle mode externally
     void setMode(InputMode m) { mode = m; }

--- a/emulation/SDLInputProvider.h
+++ b/emulation/SDLInputProvider.h
@@ -18,8 +18,8 @@ class SDLInputProvider final : public IInputProvider
     // State
 
     bool initialized = false;
-    millis_t lastAnalogActiveMs = 0;          // time of last analog engagement
-    const millis_t analogIdleTimeoutMs = 250; // revert to D-pad after this idle window
+    millis_t lastAnalogActiveMs = 0;                 // time of last analog engagement
+    const static millis_t analogIdleTimeoutMs = 250; // revert to D-pad after this idle window
     bool lmbHeld = false;
     bool rmbHeld = false;
 
@@ -42,15 +42,6 @@ class SDLInputProvider final : public IInputProvider
     // Mouse analog accumulator (velocity model)
     float vx = 0.f, vy = 0.f;
 
-    // Helpers
-    void openFirstController();
-    void closeController();
-    void setMouseRelative(bool enabled);
-
-    // Generators
-    void genDPad(InputState &s);
-    void genAnalog(InputState &s);
-
 public:
     SDLInputProvider(const InputCalibration &c = {}) : IInputProvider(c) {}
     bool init(SDL_Window *win);
@@ -72,6 +63,27 @@ public:
     InputMode getMode() const { return mode; }
 
 private:
+    // Constants
+    static constexpr float EPSILON = 1e-6f;
+
+    // Helpers
+    void openFirstController();
+    void closeController();
+    void setMouseRelative(bool enabled);
+    void normalizeToUnitCircle(float &x, float &y);
+    void useSDLAxis(float &nx, float &ny, bool &haveAnalog);
+    void useMouseDeltas(float &nx, float &ny, bool &haveAnalog);
+
+    // Generators
+    void genDPad(InputState &s);
+    void genAnalog(InputState &s);
+
+    // Event handlers
+    void handleKeyDown(const SDL_KeyboardEvent &key);
+    void handleWindowEvent(const SDL_WindowEvent &we);
+    void handleMouseButtonDown(const SDL_MouseButtonEvent &be);
+    void handleMouseButtonUp(const SDL_MouseButtonEvent &be);
+
     // Utilities
     static inline float toNormFromADC(AnalogInput_t adc)
     {

--- a/emulation/SDLMatrix32.h
+++ b/emulation/SDLMatrix32.h
@@ -47,6 +47,8 @@ public:
 
     // Initialize SDL window, renderer, streaming texture, and compute initial scale.
     void begin() override;
+    // Get the underlying SDL_Window (for input provider).
+    SDL_Window *window() const { return win_; }
     // Clear the 32x32 framebuffer to black.
     void clear() override;
     // Set a single framebuffer pixel (bounds-checked).

--- a/emulation/SDLMatrix32.h
+++ b/emulation/SDLMatrix32.h
@@ -56,6 +56,9 @@ public:
     // Present the framebuffer using the current render mode (screen or LED).
     void show() override;
 
+    // Toggle LED rendering mode.
+    void toggleLEDMode() { led_mode_ = !led_mode_; }
+
     // Draw a 5x7 glyph scaled by setTextSize() at (x,y).
     void drawChar(int x, int y, char ch, Color333 c) override;
     // Set one pixel (alias for set()).

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -48,7 +48,6 @@ void run_emulation()
         {
             app.loopOnce(); // Scene consumes ctx.time
         }
-        gfx.show();
         time.sleep_to_cadence();
     }
 }

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -11,23 +11,6 @@
 // match GRID hardware
 static constexpr double TICK_HZ = 60.0;
 
-void pollEvents(bool &running, SDLMatrix32 &gfx)
-{
-    SDL_Event e;
-    while (SDL_PollEvent(&e))
-    {
-        if (e.type == SDL_QUIT)
-            running = false; // Q triggers quit
-        if (e.type == SDL_KEYDOWN)
-        {
-            if (e.key.keysym.sym == SDLK_ESCAPE || e.key.keysym.sym == SDLK_q)
-                running = false; // ESC also triggers quit
-            else if (e.key.keysym.sym == SDLK_l)
-                gfx.setLEDMode(!gfx.ledMode()); // toggle LED mode when L is pressed
-        }
-    }
-}
-
 // Main emulation loop
 void run_emulation()
 {
@@ -57,9 +40,6 @@ void run_emulation()
 
     while (running)
     {
-        // 1) Events
-        // pollEvents(running, gfx);
-        // 2) Timing
         int steps = time.pump();
         for (int i = 0; i < steps; ++i)
         {
@@ -72,7 +52,6 @@ void run_emulation()
         // Log FPS
         printf("FPS: %5.2f\n", time.fps());
         fflush(stdout);
-        // 3) Sleep to cadence
         time.sleep_to_cadence();
     }
 }

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -36,10 +36,18 @@ void run_emulation()
     FixedStepTiming time{TICK_HZ};
     SDLInputProvider inputProvider{};
     SDL_Window *win = gfx.window();
+    bool running = true; // main loop flag
 
     // TODO handle init failure
     if (!inputProvider.init(win))
         return; // failed to init input provider
+
+    // Wire quit (Q/Esc) and LED toggle (L)
+    inputProvider.onQuit([&]
+                         { running = false; });
+    // toggle LED mode when L is pressed
+    inputProvider.onToggleLED([&]
+                              { gfx.toggleLEDMode(); });
 
     Input input{};
     input.init(&inputProvider);
@@ -47,11 +55,10 @@ void run_emulation()
 
     app.setScene<BoidsScene>();
 
-    bool running = true;
     while (running)
     {
         // 1) Events
-        pollEvents(running, gfx);
+        // pollEvents(running, gfx);
         // 2) Timing
         int steps = time.pump();
         for (int i = 0; i < steps; ++i)

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -34,7 +34,6 @@ void run_emulation()
     SDLMatrix32 gfx{};
     gfx.begin();
     FixedStepTiming time{TICK_HZ};
-    Input input{};
     SDLInputProvider inputProvider{};
     SDL_Window *win = gfx.window();
 
@@ -42,6 +41,7 @@ void run_emulation()
     if (!inputProvider.init(win))
         return; // failed to init input provider
 
+    Input input{};
     input.init(&inputProvider);
     App app{gfx, time, input};
 

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -47,8 +47,10 @@ void run_emulation()
             app.loopOnce();             // Scene consumes ctx.time
         }
         // Log inputs
-        printf("X: %5.3f Y: %5.3f Pressed: %d\n",
-               input.state().x, input.state().y, input.state().pressed ? 1 : 0);
+        printf("Raw X: %d Y: %d, Norm X: %5.3f Y: %5.3f, Pressed: %d\n",
+               input.state().x_adc, input.state().y_adc,
+               input.state().x, input.state().y,
+               input.state().pressed ? 1 : 0);
         // Log FPS
         printf("FPS: %5.2f\n", time.fps());
         fflush(stdout);


### PR DESCRIPTION
## Summary
Adds and wires up an Input component that provides input to the app. Refactored so that Input runs the only event pump.

## Type of change
- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Chore
- [ ] Docs

## Approach
I created an `Input` component, which uses an `IInputProvider` interface to sample data. Input is initialized by a platform runner, then sampled once per frame before the loop.

## Validation
- [x] Builds: `make`
- [x] Debug build OK: `make DEBUG=1` (ASan)
- [x] Runs: `make run` or `make run-debug`
- [x] No new warnings with common flags (e.g., `-Wall -Wextra`) if used

Manual test notes:
1. Steps to verify
3. Expected results
4. Edge cases

## Risk
Any breaking changes or follow-ups?
- create a `CalibrationScene` that allows user to adjust/save calibration 

## Author checklist
- [x] Conventional title (feat:, fix:, refactor:, chore:, docs:)
- [ ] Commits are small and clear
- [ ] Comments or README updated if helpful
- [ ] clang-format / clang-tidy applied or N/A
