### PR TITLE
Speed up text rendering: cached column blitter + single present per frame

### DIFF
--- a/GRID/CalibrationScene.cpp
+++ b/GRID/CalibrationScene.cpp
@@ -11,11 +11,12 @@ const char CalibrationScene::message[33] = "Press for 2 seconds to calibrate";
 void CalibrationScene::setup(AppContext &ctx)
 {
     ctx.gfx.setImmediate(false);
-    ctx.gfx.setTextSize(1);
+    int ts = 1;
+    ctx.gfx.setTextSize(ts);
 
     ScrollText banner;
-    banner.prepare(ctx.gfx, message, /*scale=*/1, WHITE);
-    banner.reset(/*startX=*/MATRIX_WIDTH, /*yTop=*/4);
+    banner.prepare(ctx.gfx, message, /*scale=*/ts, WHITE);
+    banner.reset(/*startX=*/MATRIX_WIDTH, /*yTop=*/banner.yTopCentered(ts));
 
     // Smooth scroll at 1 px per frame
     while (!banner.step(ctx.gfx, /*dx=*/-1))

--- a/GRID/CalibrationScene.cpp
+++ b/GRID/CalibrationScene.cpp
@@ -6,10 +6,10 @@
 constexpr Color333 CalibrationScene::outlineColor;
 constexpr Color333 CalibrationScene::cursorColor;
 constexpr Color333 CalibrationScene::pressedColor;
-const char CalibrationScene::message[33] = "Press for 2 seconds to calibrate";
 
 void CalibrationScene::setup(AppContext &ctx)
 {
+    static const char message[35] = "Press for 2 seconds to calibrate  ";
     ctx.gfx.setImmediate(false);
     int ts = 1;
     ctx.gfx.setTextSize(ts);

--- a/GRID/CalibrationScene.cpp
+++ b/GRID/CalibrationScene.cpp
@@ -1,5 +1,6 @@
 #include "CalibrationScene.h"
 #include "Colors.h"
+#include "ScrollTextHelper.h"
 #include <cstring>
 
 constexpr Color333 CalibrationScene::outlineColor;
@@ -9,40 +10,17 @@ const char CalibrationScene::message[33] = "Press for 2 seconds to calibrate";
 
 void CalibrationScene::setup(AppContext &ctx)
 {
-    ctx.gfx.setImmediate(false); // one present per frame
+    ctx.gfx.setImmediate(false);
     ctx.gfx.setTextSize(1);
-    ctx.gfx.setTextColor(WHITE);
 
-    static std::vector<PixelMap> msgCols;
-    ctx.gfx.buildStringCols(message, msgCols);
-    const int ts = 1; // using setTextSize(1)
-    const int totalCols = int(msgCols.size());
-    const int screenCols = MATRIX_WIDTH / ts;
-    const int y = 0;
+    ScrollText banner;
+    banner.prepare(ctx.gfx, message, /*scale=*/1, WHITE);
+    banner.reset(/*startX=*/MATRIX_WIDTH, /*yTop=*/4);
 
-    // Optional: dim background once
-    ctx.gfx.clear();
-    ctx.gfx.show();
-
-    // Scroll from right to left
-    for (int head = MATRIX_WIDTH; head > -totalCols * ts; --head)
+    // Smooth scroll at 1 px per frame
+    while (!banner.step(ctx.gfx, /*dx=*/-1))
     {
-        // Erase only the vacated 1-column strip behind the text
-        // Compute previous and current visible windows
-        // Simpler: redraw only the text region (still cheap with spans)
-        // Clear a minimal band where text is drawn
-        ctx.gfx.fillRect(0, y, MATRIX_WIDTH, FONT_GLYPH_HEIGHT * ts, BLACK);
-
-        // Determine which msg columns are visible
-        int firstCol = std::max(0, (-head + (ts - 1)) / ts);
-        int lastCol = std::min(totalCols, (MATRIX_WIDTH - head + ts - 1) / ts);
-        if (firstCol < lastCol)
-        {
-            // x position where firstCol lands
-            int x0 = head + firstCol * ts;
-            ctx.gfx.blitCols(x0, y, msgCols.data() + firstCol, lastCol - firstCol, WHITE, ts);
-        }
-        ctx.gfx.show();
+        ctx.time.sleep(20);
     }
 }
 

--- a/GRID/CalibrationScene.h
+++ b/GRID/CalibrationScene.h
@@ -10,7 +10,6 @@
 class CalibrationScene final : public Scene
 {
     static const int triggerDuration = 2000; // ms
-    static const char message[33];
     static const int circleCenter = 15;
     static const int circleRadius = 15;
     static constexpr Color333 outlineColor = GRAY;

--- a/GRID/RGBMatrix32.h
+++ b/GRID/RGBMatrix32.h
@@ -6,9 +6,6 @@
 
 using PanelColor = uint16_t;
 
-// 5x7 ASCII font declaration (defined elsewhere)
-extern const PixelMap FONT5x7[96][5];
-
 // Adapter that wraps an existing Adafruit RGBmatrixPanel
 class RGBMatrix32 : public Matrix32
 {
@@ -54,7 +51,7 @@ public:
     void clear() override;
     void set(int x, int y, Color333 c) override;
     void show() override;
-    
+
     // Drawing API (1:1 to Adafruit panel)
 
     void drawPixel(int x, int y, Color333 c) override;

--- a/GRID/ScrollTextHelper.h
+++ b/GRID/ScrollTextHelper.h
@@ -3,28 +3,69 @@
 
 #include "Matrix32.h"
 
+/**
+ * @brief Horizontally scrolling, single-line banner renderer.
+ *
+ * Usage:
+ *   ScrollText s;
+ *   s.prepare("Hello", 1, WHITE, BLACK, true, true);
+ *   s.reset(MATRIX_WIDTH, ScrollText::yTopCentered(s.ts));
+ *   while (running) { s.step(-1, gfx); }
+ */
 struct ScrollText
 {
+    /// Cached glyph columns (1-bit per pixel, 5x7 font, with inter-glyph spacing).
     std::vector<PixelMap> cols;
+
+    /// Text scale (integer, >= 1).
     int ts{1};
+    /// Foreground (text) color.
     Color333 fg{WHITE};
+    /// Background band color.
     Color333 bg{BLACK};
+    /// Whether to fill/clear the text band each frame.
     bool useBg{true};
+    /// Looping mode: wrap seamlessly when the banner exits left.
     bool loop{false};
 
-    int x{MATRIX_WIDTH}; // head position (left edge of text)
-    int y{0};            // top y of band (scaled)
+    /// Current left edge of the banner, in pixels.
+    int x{MATRIX_WIDTH};
+    /// Top Y of the text band, in pixels.
+    int y{0};
 
-    // --- Utilities ---
+    /**
+     * @brief Height in pixels of the text band for the given scale.
+     * @param ts  Text scale.
+     * @return    Band height in pixels.
+     */
     static inline int bandHeightPx(int ts) { return FONT_GLYPH_HEIGHT * ts; }
+
+    /**
+     * @brief Compute a top Y that vertically centers the band on the display.
+     * @param ts  Text scale.
+     * @return    Top Y for vertical centering.
+     */
     static inline int yTopCentered(int ts)
     {
         const int band = bandHeightPx(ts);
         return std::max(0, (MATRIX_HEIGHT - band) / 2);
     }
 
-    // --- API ---
-    void prepare(Matrix32 &m, const char *message, int scale, Color333 color, Color333 bgColor = BLACK, bool fillBackground = true, bool shouldLoop = false)
+    /**
+     * @brief Build and cache the banner’s columns and set visuals.
+     *
+     * Newlines are ignored for single-line banners.
+     *
+     * @param m                Matrix32 instance to use for graphics
+     * @param message          C-string text to scroll.
+     * @param scale            Integer scale for the 5x7 font.
+     * @param color            Foreground text color.
+     * @param bgColor          Background band color (default BLACK).
+     * @param fillBackground   If true, fills the text band each frame.
+     * @param shouldLoop       If true, enables seamless looping.
+     */
+    void prepare(Matrix32 &m, const char *message, int scale, Color333 color,
+                 Color333 bgColor = BLACK, bool fillBackground = true, bool shouldLoop = false)
     {
         ts = std::max(1, scale);
         fg = color;
@@ -34,16 +75,31 @@ struct ScrollText
         m.buildStringCols(message, cols);
     }
 
+    /**
+     * @brief Initialize scroll position and band placement.
+     *
+     * @param startX  Initial left edge (e.g., MATRIX_WIDTH to start off-screen right).
+     * @param yTop    Vertical top of the band (use yTopCentered(ts) to center).
+     */
     void reset(int startX = MATRIX_WIDTH, int yTop = 0)
     {
         x = startX;
         y = yTop;
     }
 
-    // dx negative to scroll left. Returns true when finished (non-loop), or always false when looping.
+    /**
+     * @brief Render one frame and advance position.
+     *
+     * Ensures one present per frame when Matrix32::immediate == false.
+     * If looping, draws a wrapped copy offset by the full text width.
+     *
+     * @param m   Matrix32 target renderer.
+     * @param dx  Horizontal delta in pixels per call (negative to scroll left).
+     * @return    If loop==false: true when the banner has fully exited left.
+     *            If loop==true: always false (continuous).
+     */
     bool step(Matrix32 &m, int dx)
     {
-        // Optional background band clear/fill
         if (useBg)
         {
             m.fillRect(0, y, MATRIX_WIDTH, bandHeightPx(ts), bg);
@@ -54,27 +110,25 @@ struct ScrollText
             const int totalCols = int(cols.size());
             const int totalPx = totalCols * ts;
 
-            // Visible slice in columns
-            int firstCol = std::max(0, (-x + (ts - 1)) / ts);
-            int lastCol = std::min(totalCols, (MATRIX_WIDTH - x + ts - 1) / ts);
+            const int firstCol = std::max(0, (-x + (ts - 1)) / ts);
+            const int lastCol = std::min(totalCols, (MATRIX_WIDTH - x + ts - 1) / ts);
+
             if (firstCol < lastCol)
             {
                 const int x0 = x + firstCol * ts;
                 m.blitCols(x0, y, cols.data() + firstCol, lastCol - firstCol, fg, ts);
             }
 
-            // If looping and the banner has partially or fully left the screen,
-            // draw a wrapped copy offset by totalPx to keep continuous scroll.
             if (loop)
             {
-                int x2 = x + totalPx; // next copy to the right
-                if (x2 < MATRIX_WIDTH)
+                const int xWrap = x + totalPx;
+                if (xWrap < MATRIX_WIDTH)
                 {
-                    int f2 = std::max(0, (-x2 + (ts - 1)) / ts);
-                    int l2 = std::min(totalCols, (MATRIX_WIDTH - x2 + ts - 1) / ts);
+                    const int f2 = std::max(0, (-xWrap + (ts - 1)) / ts);
+                    const int l2 = std::min(totalCols, (MATRIX_WIDTH - xWrap + ts - 1) / ts);
                     if (f2 < l2)
                     {
-                        const int x0b = x2 + f2 * ts;
+                        const int x0b = xWrap + f2 * ts;
                         m.blitCols(x0b, y, cols.data() + f2, l2 - f2, fg, ts);
                     }
                 }
@@ -84,14 +138,12 @@ struct ScrollText
         m.show();
         x += dx;
 
-        // Termination
         const int rightEdge = x + int(cols.size()) * ts;
         if (loop)
         {
-            // When fully off left, wrap x back by the text width to continue seamlessly
             if (rightEdge <= 0)
                 x += int(cols.size()) * ts;
-            return false; // looping never "finishes"
+            return false;
         }
         return (rightEdge < 0);
     }

--- a/GRID/ScrollTextHelper.h
+++ b/GRID/ScrollTextHelper.h
@@ -7,14 +7,30 @@ struct ScrollText
 {
     std::vector<PixelMap> cols;
     int ts{1};
-    Color333 color{WHITE};
-    int x{MATRIX_WIDTH}; // head position (left edge of text)
-    int y{0};
+    Color333 fg{WHITE};
+    Color333 bg{BLACK};
+    bool useBg{true};
+    bool loop{false};
 
-    void prepare(Matrix32 &m, const char *message, int scale, Color333 c)
+    int x{MATRIX_WIDTH}; // head position (left edge of text)
+    int y{0};            // top y of band (scaled)
+
+    // --- Utilities ---
+    static inline int bandHeightPx(int ts) { return FONT_GLYPH_HEIGHT * ts; }
+    static inline int yTopCentered(int ts)
+    {
+        const int band = bandHeightPx(ts);
+        return std::max(0, (MATRIX_HEIGHT - band) / 2);
+    }
+
+    // --- API ---
+    void prepare(Matrix32 &m, const char *message, int scale, Color333 color, Color333 bgColor = BLACK, bool fillBackground = true, bool shouldLoop = false)
     {
         ts = std::max(1, scale);
-        color = c;
+        fg = color;
+        bg = bgColor;
+        useBg = fillBackground;
+        loop = shouldLoop;
         m.buildStringCols(message, cols);
     }
 
@@ -24,30 +40,60 @@ struct ScrollText
         y = yTop;
     }
 
-    // dx is negative to move left, e.g. dx = -1
-    // Returns false while visible or entering, true when fully off-screen to the left
+    // dx negative to scroll left. Returns true when finished (non-loop), or always false when looping.
     bool step(Matrix32 &m, int dx)
     {
-        // Draw into a minimal band: clear only the text band
-        m.fillRect(0, y, MATRIX_WIDTH, FONT_GLYPH_HEIGHT * ts, BLACK);
+        // Optional background band clear/fill
+        if (useBg)
+        {
+            m.fillRect(0, y, MATRIX_WIDTH, bandHeightPx(ts), bg);
+        }
 
         if (!cols.empty())
         {
-            // Compute visible slice
             const int totalCols = int(cols.size());
+            const int totalPx = totalCols * ts;
+
+            // Visible slice in columns
             int firstCol = std::max(0, (-x + (ts - 1)) / ts);
             int lastCol = std::min(totalCols, (MATRIX_WIDTH - x + ts - 1) / ts);
             if (firstCol < lastCol)
             {
-                int x0 = x + firstCol * ts;
-                m.blitCols(x0, y, cols.data() + firstCol, lastCol - firstCol, color, ts);
+                const int x0 = x + firstCol * ts;
+                m.blitCols(x0, y, cols.data() + firstCol, lastCol - firstCol, fg, ts);
+            }
+
+            // If looping and the banner has partially or fully left the screen,
+            // draw a wrapped copy offset by totalPx to keep continuous scroll.
+            if (loop)
+            {
+                int x2 = x + totalPx; // next copy to the right
+                if (x2 < MATRIX_WIDTH)
+                {
+                    int f2 = std::max(0, (-x2 + (ts - 1)) / ts);
+                    int l2 = std::min(totalCols, (MATRIX_WIDTH - x2 + ts - 1) / ts);
+                    if (f2 < l2)
+                    {
+                        const int x0b = x2 + f2 * ts;
+                        m.blitCols(x0b, y, cols.data() + f2, l2 - f2, fg, ts);
+                    }
+                }
             }
         }
-        m.show();
 
-        x += dx; // advance
+        m.show();
+        x += dx;
+
+        // Termination
         const int rightEdge = x + int(cols.size()) * ts;
-        return (rightEdge < 0); // done when fully off-screen
+        if (loop)
+        {
+            // When fully off left, wrap x back by the text width to continue seamlessly
+            if (rightEdge <= 0)
+                x += int(cols.size()) * ts;
+            return false; // looping never "finishes"
+        }
+        return (rightEdge < 0);
     }
 };
 

--- a/GRID/ScrollTextHelper.h
+++ b/GRID/ScrollTextHelper.h
@@ -1,0 +1,54 @@
+#ifndef SCROLL_TEXT_HELPER_H
+#define SCROLL_TEXT_HELPER_H
+
+#include "Matrix32.h"
+
+struct ScrollText
+{
+    std::vector<PixelMap> cols;
+    int ts{1};
+    Color333 color{WHITE};
+    int x{MATRIX_WIDTH}; // head position (left edge of text)
+    int y{0};
+
+    void prepare(Matrix32 &m, const char *message, int scale, Color333 c)
+    {
+        ts = std::max(1, scale);
+        color = c;
+        m.buildStringCols(message, cols);
+    }
+
+    void reset(int startX = MATRIX_WIDTH, int yTop = 0)
+    {
+        x = startX;
+        y = yTop;
+    }
+
+    // dx is negative to move left, e.g. dx = -1
+    // Returns false while visible or entering, true when fully off-screen to the left
+    bool step(Matrix32 &m, int dx)
+    {
+        // Draw into a minimal band: clear only the text band
+        m.fillRect(0, y, MATRIX_WIDTH, FONT_GLYPH_HEIGHT * ts, BLACK);
+
+        if (!cols.empty())
+        {
+            // Compute visible slice
+            const int totalCols = int(cols.size());
+            int firstCol = std::max(0, (-x + (ts - 1)) / ts);
+            int lastCol = std::min(totalCols, (MATRIX_WIDTH - x + ts - 1) / ts);
+            if (firstCol < lastCol)
+            {
+                int x0 = x + firstCol * ts;
+                m.blitCols(x0, y, cols.data() + firstCol, lastCol - firstCol, color, ts);
+            }
+        }
+        m.show();
+
+        x += dx; // advance
+        const int rightEdge = x + int(cols.size()) * ts;
+        return (rightEdge < 0); // done when fully off-screen
+    }
+};
+
+#endif // SCROLL_TEXT_HELPER_H

--- a/emulation/SDLMatrix32.h
+++ b/emulation/SDLMatrix32.h
@@ -9,9 +9,6 @@ struct SDL_Window;
 struct SDL_Renderer;
 struct SDL_Texture;
 
-// 5x7 ASCII font declaration (defined elsewhere)
-extern const PixelMap FONT5x7[96][5];
-
 // Parameters that control how each logical LED cell is rendered on screen.
 // - scale:  number of screen pixels per 1 matrix pixel
 // - margin: black bezel around the LED inside the cell (in screen pixels)


### PR DESCRIPTION
## Summary
Optimizes text drawing via a new `blitCols` that draws sentences smoothly, adding helpers and comments. This was mostly implemented with the help of Notion AI. Fixes issue with text banners.

## Type of change
- [x] Feature
- [x] Bug fix
- [x] Refactor
- [ ] Chore
- [ ] Docs

## Approach
- Pre-renders message into 1-bit columns and scrolls a visible window.
- Uses `Matrix32::blitCols` to draw vertical spans per column, replacing per-pixel writes.
- Ensures `immediate=false` to present once per frame. Avoids full clears by redrawing only the text band.
- SDL LED mode can be disabled during scroll for further gains.

Includes
- Matrix32 helpers: `buildGlyphCols`, `buildStringCols`
- New `Matrix32::blitCols` member
- `CalibrationScene` updated to call `ctx.gfx.blitCols`

## Validation
- [x] Builds: `make`
- [ ] Debug build OK: `make DEBUG=1` (ASan)
- [x] Runs: `make run` or `make run-debug`
- [ ] No new warnings with common flags (e.g., `-Wall -Wextra`) if used


## Author checklist
- [ ] Conventional title (feat:, fix:, refactor:, chore:, docs:)
- [ ] Commits are small and clear
- [x] Comments or README updated if helpful
- [x] clang-format / clang-tidy applied or N/A
