### PR TITLE
bug: Fix emulation controls

### DIFF
--- a/emulation/SDLInputProvider.cpp
+++ b/emulation/SDLInputProvider.cpp
@@ -185,6 +185,16 @@ void SDLInputProvider::sample(InputState &state)
     }
 }
 
+void SDLInputProvider::clampMagnitudeToOne(float &x, float &y)
+{
+    float m = std::sqrt(x * x + y * y);
+    if (m > 1.f && m > InputTuning::EPSILON)
+    {
+        x /= m;
+        y /= m;
+    }
+}
+
 void SDLInputProvider::normalizeToUnitCircle(float &x, float &y)
 {
     float mag = std::sqrt(x * x + y * y);
@@ -294,7 +304,7 @@ void SDLInputProvider::genAnalog(InputState &s)
         return;
     }
 
-    normalizeToUnitCircle(nx, ny);
+    clampMagnitudeToOne(s.x, s.y);
 
     if (invertY) // typical camera-style invert
         ny = -ny;

--- a/emulation/SDLInputProvider.h
+++ b/emulation/SDLInputProvider.h
@@ -72,14 +72,14 @@ public:
     // Experimentally determined defaults (documented)
     // deadzone: ignore |v| < 0.02; gamma: response curve exponent
     static constexpr InputCalibration defaultCalib{
-        .deadzone = 0.02f, // was .02f
-        .gamma = 1.8f,
-        .x_adc_low = InputCalibration::ADC_MIN,
-        .x_adc_center = (InputCalibration::ADC_MAX - InputCalibration::ADC_MIN) / 2,
-        .x_adc_high = InputCalibration::ADC_MAX,
-        .y_adc_low = InputCalibration::ADC_MIN,
-        .y_adc_center = (InputCalibration::ADC_MAX - InputCalibration::ADC_MIN) / 2,
-        .y_adc_high = InputCalibration::ADC_MAX,
+        0.02f,                                                       // deadzone
+        1.8f,                                                        // gamma
+        InputCalibration::ADC_MIN,                                   // x_adc_low
+        (InputCalibration::ADC_MAX - InputCalibration::ADC_MIN) / 2, // x_adc_center
+        InputCalibration::ADC_MAX,                                   // x_adc_high
+        InputCalibration::ADC_MIN,                                   // y_adc_low
+        (InputCalibration::ADC_MAX - InputCalibration::ADC_MIN) / 2, // y_adc_center
+        InputCalibration::ADC_MAX,                                   // y_adc_high
     };
 
     SDLInputProvider(const InputCalibration &c = defaultCalib) : IInputProvider(c) {}

--- a/emulation/SDLInputProvider.h
+++ b/emulation/SDLInputProvider.h
@@ -111,6 +111,7 @@ private:
     void closeController();
     void setMouseRelative(bool enabled);
 
+    void clampMagnitudeToOne(float &x, float &y);
     void normalizeToUnitCircle(float &x, float &y);
     void useSDLAxis(float &nx, float &ny, bool &haveAnalog);
     void useMouseDeltas(float &nx, float &ny, bool &haveAnalog);


### PR DESCRIPTION
## Summary
What does this change do and why?
- Fixes emulation mouse input

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs

## Approach
- Added a fix to genAnalog, remove renormalization and added new clamp function.

## Validation
- [x] Builds: `make`
- [x] Debug build OK: `make DEBUG=1` (ASan)
- [x] Runs: `make run` or `make run-debug`
- [x] No new warnings with common flags (e.g., `-Wall -Wextra`) if used

Manual test notes:
1. Steps to verify
2. Expected results
3. Edge cases

## Risk
Any breaking changes or follow-ups?

## Author checklist
- [ ] Conventional title (feat:, fix:, refactor:, chore:, docs:)
- [x] Commits are small and clear
- [ ] Comments or README updated if helpful
- [ ] clang-format / clang-tidy applied or N/A
