### PR TITLE
Fix: led resize is correct, and both modes respect aspect ratio

### DIFF
--- a/emulation/SDLInputProvider.cpp
+++ b/emulation/SDLInputProvider.cpp
@@ -93,6 +93,11 @@ void SDLInputProvider::handleWindowEvent(const SDL_WindowEvent &we)
         lmbHeld = rmbHeld = false;
         vx = vy = 0.f;
     }
+    else if (we.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+    {
+        if (resizeCb)
+            resizeCb();
+    }
 }
 
 void SDLInputProvider::handleMouseButtonDown(const SDL_MouseButtonEvent &be)

--- a/emulation/SDLInputProvider.h
+++ b/emulation/SDLInputProvider.h
@@ -57,6 +57,7 @@ class SDLInputProvider final : public IInputProvider
     // Callbacks
     std::function<void()> quitCb;      // Q or Esc
     std::function<void()> toggleLEDCb; // L
+    std::function<void()> resizeCb;    // resize window
 
     // Config
     InputMode mode = InputMode::DPad; // whether to use D‑pad or analog mode
@@ -93,6 +94,7 @@ public:
     // Hooks
     void onQuit(std::function<void()> cb) { quitCb = std::move(cb); }
     void onToggleLED(std::function<void()> cb) { toggleLEDCb = std::move(cb); }
+    void onResize(std::function<void()> cb) { resizeCb = std::move(cb); }
 
     // Fills state based on current mode and devices
     void sample(InputState &state) override;

--- a/emulation/SDLMatrix32.cpp
+++ b/emulation/SDLMatrix32.cpp
@@ -50,10 +50,7 @@ void SDLMatrix32::begin()
     if (!tex_)
         throw std::runtime_error(SDL_GetError());
     clear();
-    int w{0};
-    int h{0};
-    SDL_GetWindowSize(win_, &w, &h);
-    scale_ = std::max(1, std::min(w, h) / MATRIX_WIDTH);
+    recomputeScale();
     // Pump once so macOS shows the window promptly
     SDL_PumpEvents();
 }
@@ -253,6 +250,15 @@ void SDLMatrix32::println(const char *s)
 {
     print(s);
     print('\n');
+}
+
+// Minimal helper: recompute integer scale_ from current renderer output size
+void SDLMatrix32::recomputeScale()
+{
+    int outW = 0, outH = 0;
+    SDL_GetRendererOutputSize(ren_, &outW, &outH); // HiDPI-safe
+    const int square = std::min(outW, outH);
+    scale_ = std::max(1, square / MATRIX_WIDTH);
 }
 
 // Render one matrix pixel as a circular LED inside a black cell

--- a/emulation/SDLMatrix32.cpp
+++ b/emulation/SDLMatrix32.cpp
@@ -271,7 +271,7 @@ void SDLMatrix32::renderPixelAsLED(int x, int y, const LEDcell &cell)
     const int cy_led = sy + cell.margin + cell.inner / 2;
 
     // Color from framebuffer (dim "off" LED for dome look)
-    const auto pix = fb_[y * MATRIX_HEIGHT + x];
+    const auto pix = fb_[coordToIndex(x, y)];
     Intensity8 r = pix.r, g = pix.g, b = pix.b;
     if ((r | g | b) == 0)
         r = g = b = 12;

--- a/emulation/SDLMatrix32.cpp
+++ b/emulation/SDLMatrix32.cpp
@@ -259,13 +259,18 @@ void SDLMatrix32::recomputeScale()
     SDL_GetRendererOutputSize(ren_, &outW, &outH); // HiDPI-safe
     const int square = std::min(outW, outH);
     scale_ = std::max(1, square / MATRIX_WIDTH);
+
+    // Centered offsets for LED canvas
+    const int canvas = scale_ * MATRIX_WIDTH;
+    ledOffsetX_ = (outW - canvas) / 2;
+    ledOffsetY_ = (outH - canvas) / 2;
 }
 
 // Render one matrix pixel as a circular LED inside a black cell
 void SDLMatrix32::renderPixelAsLED(int x, int y, const LEDcell &cell)
 {
-    const int sx = x * cell.scale;
-    const int sy = y * cell.scale;
+    const int sx = ledOffsetX_ + x * cell.scale;
+    const int sy = ledOffsetY_ + y * cell.scale;
 
     // Bezel
     SetRGBA(ren_, 0, 0, 0, 255);
@@ -278,6 +283,7 @@ void SDLMatrix32::renderPixelAsLED(int x, int y, const LEDcell &cell)
 
     // Color from framebuffer (dim "off" LED for dome look)
     const auto pix = fb_[coordToIndex(x, y)];
+
     Intensity8 r = pix.r, g = pix.g, b = pix.b;
     if ((r | g | b) == 0)
         r = g = b = 12;

--- a/emulation/SDLMatrix32.cpp
+++ b/emulation/SDLMatrix32.cpp
@@ -50,6 +50,8 @@ void SDLMatrix32::begin()
     if (!tex_)
         throw std::runtime_error(SDL_GetError());
     clear();
+    SDL_RenderSetLogicalSize(ren_, MATRIX_WIDTH, MATRIX_HEIGHT);
+    SDL_RenderSetIntegerScale(ren_, SDL_TRUE); // keeps integer scale and centers
     recomputeScale();
     // Pump once so macOS shows the window promptly
     SDL_PumpEvents();
@@ -316,7 +318,7 @@ void SDLMatrix32::renderAsScreen()
         SDL_UnlockTexture(tex_);
     }
     SDL_RenderClear(ren_);
-    SDL_RenderCopy(ren_, tex_, nullptr, nullptr);
+    SDL_RenderCopy(ren_, tex_, nullptr, nullptr); // NULL dst uses logical size
     SDL_RenderPresent(ren_);
 }
 

--- a/emulation/SDLMatrix32.h
+++ b/emulation/SDLMatrix32.h
@@ -90,6 +90,9 @@ public:
     void setLEDMode(bool on) { led_mode_ = on; }
     bool ledMode() const { return led_mode_; }
 
+    // Minimal helper: recompute integer scale_ from current renderer output size
+    void recomputeScale();
+
     // Render one matrix pixel as an LED circle into the SDL renderer.
     void renderPixelAsLED(int x, int y, const LEDcell &cell);
     // Render the entire framebuffer as an LED matrix.

--- a/emulation/SDLMatrix32.h
+++ b/emulation/SDLMatrix32.h
@@ -119,6 +119,8 @@ private:
     // Rendering options
     bool led_mode_{false};
     int scale_{16}; // screen pixels per logical LED
+    int ledOffsetX_{0};
+    int ledOffsetY_{0};
 
     // Low-level framebuffer helpers
     void span(int x0, int x1, int y, Color333 c); // clamped horizontal span

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -85,6 +85,9 @@ void run_emulation()
     // toggle LED mode when L is pressed
     inputProvider.onToggleLED([&]
                               { gfx.toggleLEDMode(); });
+    // resize window updates LED size
+    inputProvider.onResize([&]
+                           { gfx.recomputeScale(); });
 
     Input input{};
     input.init(&inputProvider);


### PR DESCRIPTION
## Summary
What does this change do and why?
- rescales LED mode correctly on resize
- fixes aspect ratio to square for both modes
- fix minor index issue

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs

## Approach
How did you implement it? Any tradeoffs or alternatives considered?

Notion AI was very helpful for this.

## Validation
- [x] Builds: `make`
- [x] Debug build OK: `make DEBUG=1` (ASan)
- [x] Runs: `make run` or `make run-debug`
- [x] No new warnings with common flags (e.g., `-Wall -Wextra`) if used

Manual test notes:
1. Steps to verify
2. Expected results
3. Edge cases

## Risk
Any breaking changes or follow-ups?

## Author checklist
- [x] Conventional title (feat:, fix:, refactor:, chore:, docs:)
- [x] Commits are small and clear
- [ ] Comments or README updated if helpful
- [ ] clang-format / clang-tidy applied or N/A
