### PR TITLE
feat: create menu scene

### DIFF
--- a/GRID/App.h
+++ b/GRID/App.h
@@ -56,6 +56,7 @@ public:
         ctx.time.resetSceneClock();
         // immediate only during setup (works on SDLMatrix32, no-op on Arduino)
         ctx.gfx.setImmediate(true);
+        ctx.gfx.clear();
         current->setup(ctx);
         ctx.gfx.setImmediate(false);
     }

--- a/GRID/App.h
+++ b/GRID/App.h
@@ -26,6 +26,53 @@ class App
     std::unique_ptr<Scene> current;
     SceneBus bus{};
 
+    // --- Quit-to-menu state ---
+    millis_t quitHoldStartMs_ = 0;
+    bool quitPrevPressed_ = false;
+    bool quitArmed_ = false;
+    static constexpr millis_t QUIT_HOLD_MS = 5000;
+
+    bool checkQuitToMenu_()
+    {
+        const InputState s = ctx.input.state();
+        const millis_t now = ctx.time.nowMs();
+
+        if (s.pressed)
+        {
+            // Rising edge: start timing
+            if (!quitPrevPressed_)
+            {
+                quitHoldStartMs_ = now;
+            }
+            // Arm once threshold reached (do not switch yet)
+            if (!quitArmed_ && quitHoldStartMs_ && (now - quitHoldStartMs_) >= QUIT_HOLD_MS)
+            {
+                quitArmed_ = true;
+            }
+        }
+        else
+        {
+            // Button released: fire if armed
+            if (quitArmed_)
+            {
+                quitArmed_ = false;
+                quitHoldStartMs_ = 0;
+                quitPrevPressed_ = s.pressed;
+
+                // Switch scenes here. If you have a MenuScene route bound on a bus:
+                if (ctx.bus && ctx.bus->toMenu)
+                    ctx.bus->toMenu();
+                else
+                    this->setScene<MenuScene>();
+                return true;
+            }
+            // Not armed -> just cancel timer
+            quitHoldStartMs_ = 0;
+        }
+        quitPrevPressed_ = s.pressed;
+        return false;
+    }
+
 public:
     explicit App(Matrix32 &gfx, Timing &time, Input &input, ILogger &logger, IStorage &storage) : ctx{gfx, time, input, logger, storage}
     {
@@ -66,6 +113,8 @@ public:
     void loopOnce()
     {
         ctx.input.sample();
+        if (checkQuitToMenu_())
+            return; // handle global quit before scene logic
         current->loop(ctx);
         ctx.gfx.show();
     }

--- a/GRID/App.h
+++ b/GRID/App.h
@@ -13,14 +13,33 @@
 #include "RGBMatrix32.h"
 #endif
 
+#include "SceneBus.h"
+#include "BoidsScene.h"
+#include "CalibrationScene.h"
+#include "ExampleScene.h"
+#include "MenuScene.h"
+
 // App manages the current scene; only holds Matrix32&
 class App
 {
     AppContext ctx;
     std::unique_ptr<Scene> current;
+    SceneBus bus{};
 
 public:
-    explicit App(Matrix32 &gfx, Timing &time, Input &input, ILogger &logger, IStorage &storage) : ctx{gfx, time, input, logger, storage} {}
+    explicit App(Matrix32 &gfx, Timing &time, Input &input, ILogger &logger, IStorage &storage) : ctx{gfx, time, input, logger, storage}
+    {
+        ctx.bus = &bus;
+        // Bind routes. Lambdas capture this App and call setScene.
+        bus.toMenu = [this]
+        { this->setScene<MenuScene>(); };
+        bus.toExample = [this]
+        { this->setScene<ExampleScene>(); };
+        bus.toBoids = [this]
+        { this->setScene<BoidsScene>(); };
+        bus.toCalibration = [this]
+        { this->setScene<CalibrationScene>(); };
+    }
 
     // Replace the current scene with a newly constructed SceneT.
     // - Destroys the old scene, creates SceneT(args...), then calls setup(gfx).

--- a/GRID/AppContext.h
+++ b/GRID/AppContext.h
@@ -7,6 +7,9 @@
 #include "Logging.h"
 #include "IStorage.h"
 
+// forward decl to avoid header coupling
+struct SceneBus;
+
 struct AppContext
 {
     Matrix32 &gfx;     // reference to Matrix 32x32 graphics
@@ -14,6 +17,9 @@ struct AppContext
     Input &input;      // reference to input interface
     ILogger &logger;   // reference to logger interface
     IStorage &storage; // reference to storage interface
+
+    // Optional scene router; set by App. May be null in older code.
+    SceneBus *bus = nullptr;
 };
 
 #endif // APP_CONTEXT_H

--- a/GRID/CalibrationScene.cpp
+++ b/GRID/CalibrationScene.cpp
@@ -18,7 +18,7 @@ void CalibrationScene::setup(AppContext &ctx)
     ctx.gfx.setImmediate(true);
     int ts = 1;
     ctx.gfx.setTextSize(ts);
-    Color333 tc = WHITE;
+    Color333 tc = GRAY;
     ctx.gfx.setTextColor(tc);
 
     ctx.gfx.setCursor(1, 1);
@@ -140,7 +140,7 @@ void CalibrationScene::drawStage(AppContext &ctx)
     const int BAR_START_Y = 29;
     const int BAR_WIDTH = 29;
     const int BAR_HEIGHT = 2;
-    constexpr Color333 BAR_COLOR = YELLOW;
+    constexpr Color333 BAR_COLOR = Color333{1, 1, 0};
     const millis_t elapsed = ctx.time.nowMs() - (stage_start_ + TRANSITION_BUFFER);
     const float progress = float(elapsed) / float(STAGE_MS);
     const int elapsed_width = round(BAR_WIDTH * (1.0f - progress));

--- a/GRID/CalibrationScene.cpp
+++ b/GRID/CalibrationScene.cpp
@@ -18,7 +18,7 @@ void CalibrationScene::setup(AppContext &ctx)
     ctx.gfx.setImmediate(true);
     int ts = 1;
     ctx.gfx.setTextSize(ts);
-    Color333 tc = GRAY;
+    Color333 tc = Colors::Muted::White;
     ctx.gfx.setTextColor(tc);
 
     ctx.gfx.setCursor(1, 1);
@@ -145,7 +145,7 @@ void CalibrationScene::drawStage(AppContext &ctx)
     const float progress = float(elapsed) / float(STAGE_MS);
     const int elapsed_width = round(BAR_WIDTH * (1.0f - progress));
     // draw over old bar
-    ctx.gfx.fillRect(BAR_START_X, BAR_START_Y, BAR_WIDTH, BAR_HEIGHT, BLACK);
+    ctx.gfx.fillRect(BAR_START_X, BAR_START_Y, BAR_WIDTH, BAR_HEIGHT, Colors::Black);
     ctx.gfx.fillRect(BAR_START_X, BAR_START_Y, elapsed_width, BAR_HEIGHT, BAR_COLOR);
 }
 

--- a/GRID/CalibrationScene.h
+++ b/GRID/CalibrationScene.h
@@ -16,11 +16,11 @@ class CalibrationScene final : public Scene
     static const millis_t TRANSITION_BUFFER = 1000; // buffer between state transitions
     static const int CIRCLE_CENTER = 15;
     static const int CIRCLE_RADIUS = 15;
-    static constexpr Color333 CIRCLE_COLOR = GRAY;
+    static constexpr Color333 CIRCLE_COLOR = Colors::Muted::White;
     static constexpr Color333 PRESSED_COLOR = Color333{0, 1, 0};
     static constexpr Color333 IDLE_COLOR = Color333{1, 0, 0};
-    static constexpr Color333 PRESSED_CURSOR_COLOR = GREEN;
-    static constexpr Color333 IDLE_CURSOR_COLOR = RED;
+    static constexpr Color333 PRESSED_CURSOR_COLOR = Colors::Bright::Green;
+    static constexpr Color333 IDLE_CURSOR_COLOR = Colors::Bright::Red;
     static constexpr float DZ_BUFFER = 1.5;  // buffer to add to deadzone calibration
     static constexpr float DZ_CEILING = 0.1; // max deadzone for calibration
 

--- a/GRID/Colors.h
+++ b/GRID/Colors.h
@@ -16,19 +16,37 @@ struct Color888
     Intensity8 r, g, b; // RGB are each 0..255
 };
 
-#define BLACK (Color333{0, 0, 0})
-#define WHITE (Color333{7, 7, 7})
-#define RED (Color333{7, 0, 0})
-#define GREEN (Color333{0, 7, 0})
-#define BLUE (Color333{0, 0, 7})
-#define YELLOW (Color333{7, 7, 0})
-#define CYAN (Color333{0, 7, 7})
-#define VIOLET (Color333{7, 0, 7})
-#define ORANGE (Color333{7, 3, 0})
-#define LIME (Color333{4, 7, 0})
-#define AZURE (Color333{0, 3, 7})
-#define PURPLE (Color333{4, 0, 7})
-#define PINK (Color333{7, 0, 4})
-#define GRAY (Color333{1, 1, 1})
+// Color constants (3-3-3)
+namespace Colors
+{
+    constexpr Color333 Black{0, 0, 0};
+    namespace Muted
+    {
+        constexpr Color333 White{1, 1, 1};
+        constexpr Color333 Red{1, 0, 0};
+        constexpr Color333 Green{0, 1, 0};
+        constexpr Color333 Blue{0, 0, 1};
+        constexpr Color333 Yellow{1, 1, 0};
+        constexpr Color333 Cyan{0, 1, 1};
+        constexpr Color333 Violet{1, 0, 1}; // aka Magenta at full intensity
+    }
+
+    namespace Bright
+    {
+        constexpr Color333 Black{0, 0, 0};
+        constexpr Color333 White{7, 7, 7};
+        constexpr Color333 Red{7, 0, 0};
+        constexpr Color333 Green{0, 7, 0};
+        constexpr Color333 Blue{0, 0, 7};
+        constexpr Color333 Yellow{7, 7, 0};
+        constexpr Color333 Cyan{0, 7, 7};
+        constexpr Color333 Violet{7, 0, 7}; // aka Magenta at full intensity
+        constexpr Color333 Orange{7, 3, 0};
+        constexpr Color333 Lime{4, 7, 0};
+        constexpr Color333 Azure{0, 3, 7};
+        constexpr Color333 Purple{4, 0, 7};
+        constexpr Color333 Pink{7, 0, 4};
+    }
+}
 
 #endif // COLORS_H

--- a/GRID/ExampleScene.cpp
+++ b/GRID/ExampleScene.cpp
@@ -6,28 +6,28 @@
 void ExampleScene::setup(AppContext &ctx)
 {
     // draw a pixel in solid white
-    ctx.gfx.drawPixel(0, 0, WHITE);
+    ctx.gfx.drawPixel(0, 0, Colors::Bright::White);
     ctx.time.sleep(500);
 
     // fix the screen with green
-    ctx.gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, GREEN);
+    ctx.gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, Colors::Bright::Green);
     ctx.time.sleep(500);
 
     // draw a box in yellow
-    ctx.gfx.drawRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, YELLOW);
+    ctx.gfx.drawRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, Colors::Bright::Yellow);
     ctx.time.sleep(500);
 
     // draw an 'X' in red
-    ctx.gfx.drawLine(0, 0, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 1, RED);
-    ctx.gfx.drawLine(MATRIX_WIDTH - 1, 0, 0, MATRIX_HEIGHT - 1, RED);
+    ctx.gfx.drawLine(0, 0, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 1, Colors::Bright::Red);
+    ctx.gfx.drawLine(MATRIX_WIDTH - 1, 0, 0, MATRIX_HEIGHT - 1, Colors::Bright::Red);
     ctx.time.sleep(500);
 
     // draw a blue circle
-    ctx.gfx.drawCircle(10, 10, 10, BLUE);
+    ctx.gfx.drawCircle(10, 10, 10, Colors::Bright::Blue);
     ctx.time.sleep(500);
 
     // fill a violet circle
-    ctx.gfx.fillCircle(21, 21, 10, VIOLET);
+    ctx.gfx.fillCircle(21, 21, 10, Colors::Bright::Violet);
     ctx.time.sleep(500);
 
     ctx.gfx.clear();
@@ -37,31 +37,31 @@ void ExampleScene::setup(AppContext &ctx)
     ctx.gfx.setTextSize(1);  // size 1 == 8 pixels high
     // ctx.gfx.setTextWrap(false); // Don't wrap at end of line - will do ourselves
 
-    ctx.gfx.setTextColor(WHITE);
+    ctx.gfx.setTextColor(Colors::Bright::White);
     ctx.gfx.println(" Ada");
     ctx.gfx.println("fruit");
 
     // print each letter with a rainbow color
-    ctx.gfx.setTextColor(RED);
+    ctx.gfx.setTextColor(Colors::Bright::Red);
     ctx.gfx.print('3');
-    ctx.gfx.setTextColor(ORANGE);
+    ctx.gfx.setTextColor(Colors::Bright::Orange);
     ctx.gfx.print('2');
-    ctx.gfx.setTextColor(YELLOW);
+    ctx.gfx.setTextColor(Colors::Bright::Yellow);
     ctx.gfx.print('x');
-    ctx.gfx.setTextColor(LIME);
+    ctx.gfx.setTextColor(Colors::Bright::Lime);
     ctx.gfx.print('3');
-    ctx.gfx.setTextColor(GREEN);
+    ctx.gfx.setTextColor(Colors::Bright::Green);
     ctx.gfx.println("2");
 
-    ctx.gfx.setTextColor(CYAN);
+    ctx.gfx.setTextColor(Colors::Bright::Cyan);
     ctx.gfx.print('*');
-    ctx.gfx.setTextColor(AZURE);
+    ctx.gfx.setTextColor(Colors::Bright::Azure);
     ctx.gfx.print('R');
-    ctx.gfx.setTextColor(BLUE);
+    ctx.gfx.setTextColor(Colors::Bright::Blue);
     ctx.gfx.print('G');
-    ctx.gfx.setTextColor(PURPLE);
+    ctx.gfx.setTextColor(Colors::Bright::Purple);
     ctx.gfx.print('B');
-    ctx.gfx.setTextColor(PINK);
+    ctx.gfx.setTextColor(Colors::Bright::Pink);
     ctx.gfx.print('*');
 
     // whew!

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -2,14 +2,12 @@
 #include "ArduinoInputProvider.h"
 #include "ArduinoLogger.h"
 #include "ArduinoPassiveTiming.h"
-#include "BoidsScene.h"
-#include "CalibrationScene.h"
-#include "ExampleScene.h"
 #include "RGBMatrix32.h"
 #include <RGBmatrixPanel.h>
 #include "FlashStorage.h"
 #include "Input.h"
 #include "IStorage.h"
+#include "MenuScene.h"
 
 // Adafruit flash + FatFs globals
 #include "SdFat_Adafruit_Fork.h"
@@ -184,7 +182,7 @@ void setup()
     // run_flash_storage_smoke(logger);
     // smokeTest(gfx, timing); // uncomment to run smoke tests before main app
 
-    app.setScene<CalibrationScene>();
+    app.setScene<MenuScene>();
     prev_millis = millis();
     log_last_ms = prev_millis;
 }

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -118,7 +118,7 @@ static void smokeTest(Matrix32 &gfx, Timing &timing)
     gfx.setImmediate(true);
 
     // Solid green
-    gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, GREEN);
+    gfx.fillRect(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, Colors::Bright::Green);
     timing.sleep(2000);
 
     // Alternating rows
@@ -127,7 +127,7 @@ static void smokeTest(Matrix32 &gfx, Timing &timing)
     {
         for (int x = 0; x < MATRIX_WIDTH; ++x)
         {
-            gfx.drawPixel(x, y, (y & 1) ? RED : GREEN);
+            gfx.drawPixel(x, y, (y & 1) ? Colors::Bright::Red : Colors::Bright::Green);
         }
     }
     timing.sleep(2000);
@@ -136,7 +136,7 @@ static void smokeTest(Matrix32 &gfx, Timing &timing)
     gfx.clear();
     gfx.setCursor(1, 0);
     gfx.setTextSize(1);
-    gfx.setTextColor(WHITE);
+    gfx.setTextColor(Colors::Bright::White);
     gfx.println("GRID");
     timing.sleep(1000);
     gfx.setCursor(1, 10);

--- a/GRID/MenuScene.cpp
+++ b/GRID/MenuScene.cpp
@@ -1,0 +1,83 @@
+#include "MenuScene.h"
+
+void MenuScene::loop(AppContext &ctx)
+{
+    const InputState s = ctx.input.state();
+
+    // Basic nav: X left/right to change selection, button to activate
+    // Simple hysteresis with thresholds
+    const float TH = 0.45f;
+    static bool prevLeft = false, prevRight = false, prevPress = false;
+
+    bool left = (s.x < -TH);
+    bool right = (s.x > TH);
+    bool press = s.pressed;
+
+    if (right && !prevRight)
+        next();
+    if (left && !prevLeft)
+        prev();
+
+    // Draw menu each frame
+    draw(ctx);
+
+    if (press && !prevPress && ctx.bus)
+    {
+        switch (selected)
+        {
+        case Item::Example:
+            ctx.bus->toExample();
+            return;
+        case Item::Boids:
+            ctx.bus->toBoids();
+            return;
+        case Item::Calibration:
+            ctx.bus->toCalibration();
+            return;
+        default:
+            break;
+        }
+    }
+
+    prevLeft = left;
+    prevRight = right;
+    prevPress = press;
+}
+
+void MenuScene::next()
+{
+    int v = static_cast<int>(selected);
+    v = (v + 1) % static_cast<int>(Item::COUNT);
+    selected = static_cast<Item>(v);
+}
+
+void MenuScene::prev()
+{
+    int v = static_cast<int>(selected);
+    v = (v - 1 + static_cast<int>(Item::COUNT)) % static_cast<int>(Item::COUNT);
+    selected = static_cast<Item>(v);
+}
+
+void MenuScene::draw(AppContext &ctx)
+{
+    ctx.gfx.clear();
+    ctx.gfx.setTextSize(1);
+    ctx.gfx.setCursor(1, 1);
+
+    ctx.gfx.print("Menu:");
+
+    auto printItem = [&](const char *label, bool sel)
+    {
+        ctx.gfx.setTextColor(sel ? GREEN : WHITE);
+        ctx.gfx.println(label);
+    };
+
+    printItem("E.g.", selected == Item::Example);
+    printItem("Boids", selected == Item::Boids);
+    printItem("Calib", selected == Item::Calibration);
+
+    // arrow hint
+    ctx.gfx.setCursor(1, MATRIX_HEIGHT - 8);
+    ctx.gfx.setTextColor(WHITE);
+    ctx.gfx.print("<OK>");
+}

--- a/GRID/MenuScene.cpp
+++ b/GRID/MenuScene.cpp
@@ -108,6 +108,6 @@ const char *MenuScene::label(const MenuScene::Item scene) const
     case MenuScene::Item::Calibration:
         return "Calib";
     default:
-        break;
+        return "NULL";
     }
 }

--- a/GRID/MenuScene.cpp
+++ b/GRID/MenuScene.cpp
@@ -21,6 +21,9 @@ void MenuScene::loop(AppContext &ctx)
 
     if (press && !prevPress && ctx.bus)
     {
+        // shows center press with a small pause
+        ctx.gfx.show();
+        ctx.time.sleep(SELECT_PAUSE);
         switch (selected)
         {
         case Item::Example:
@@ -65,6 +68,10 @@ void MenuScene::draw(AppContext &ctx, bool left, bool right, bool press)
 
     ctx.gfx.print("Menu:");
     ctx.gfx.setCursor(1, 12);
+    if (press)
+        ctx.gfx.setTextColor(WHITE);
+    else
+        ctx.gfx.setTextColor(GRAY);
     ctx.gfx.println(label(selected));
 
     // arrow hint

--- a/GRID/MenuScene.cpp
+++ b/GRID/MenuScene.cpp
@@ -5,21 +5,19 @@ void MenuScene::loop(AppContext &ctx)
     const InputState s = ctx.input.state();
 
     // Basic nav: X left/right to change selection, button to activate
-    // Simple hysteresis with thresholds
-    const float TH = 0.45f;
     static bool prevLeft = false, prevRight = false, prevPress = false;
 
-    bool left = (s.x < -TH);
-    bool right = (s.x > TH);
+    bool left = (s.x < -MenuScene::HYSTERESIS_THRESHOLD);
+    bool right = (s.x > MenuScene::HYSTERESIS_THRESHOLD);
     bool press = s.pressed;
 
-    if (right && !prevRight)
-        next();
     if (left && !prevLeft)
+        next();
+    if (right && !prevRight)
         prev();
 
     // Draw menu each frame
-    draw(ctx);
+    draw(ctx, left, right, press);
 
     if (press && !prevPress && ctx.bus)
     {
@@ -58,26 +56,51 @@ void MenuScene::prev()
     selected = static_cast<Item>(v);
 }
 
-void MenuScene::draw(AppContext &ctx)
+void MenuScene::draw(AppContext &ctx, bool left, bool right, bool press)
 {
     ctx.gfx.clear();
     ctx.gfx.setTextSize(1);
     ctx.gfx.setCursor(1, 1);
+    ctx.gfx.setTextColor(GRAY);
 
     ctx.gfx.print("Menu:");
-
-    auto printItem = [&](const char *label, bool sel)
-    {
-        ctx.gfx.setTextColor(sel ? GREEN : WHITE);
-        ctx.gfx.println(label);
-    };
-
-    printItem("E.g.", selected == Item::Example);
-    printItem("Boids", selected == Item::Boids);
-    printItem("Calib", selected == Item::Calibration);
+    ctx.gfx.setCursor(1, 12);
+    ctx.gfx.println(label(selected));
 
     // arrow hint
     ctx.gfx.setCursor(1, MATRIX_HEIGHT - 8);
-    ctx.gfx.setTextColor(WHITE);
-    ctx.gfx.print("<OK>");
+    if (left)
+        ctx.gfx.setTextColor(WHITE);
+    else
+        ctx.gfx.setTextColor(GRAY);
+    ctx.gfx.print("<");
+
+    ctx.gfx.setCursor(10, MATRIX_HEIGHT - 8);
+    if (press)
+        ctx.gfx.setTextColor(WHITE);
+    else
+        ctx.gfx.setTextColor(GRAY);
+    ctx.gfx.print("OK");
+
+    if (right)
+        ctx.gfx.setTextColor(WHITE);
+    else
+        ctx.gfx.setTextColor(GRAY);
+    ctx.gfx.setCursor(MATRIX_WIDTH - 6, MATRIX_HEIGHT - 8);
+    ctx.gfx.print(">");
+}
+
+const char *MenuScene::label(const MenuScene::Item scene) const
+{
+    switch (scene)
+    {
+    case MenuScene::Item::Example:
+        return "E.g.";
+    case MenuScene::Item::Boids:
+        return "Boids";
+    case MenuScene::Item::Calibration:
+        return "Calib";
+    default:
+        break;
+    }
 }

--- a/GRID/MenuScene.cpp
+++ b/GRID/MenuScene.cpp
@@ -64,35 +64,35 @@ void MenuScene::draw(AppContext &ctx, bool left, bool right, bool press)
     ctx.gfx.clear();
     ctx.gfx.setTextSize(1);
     ctx.gfx.setCursor(1, 1);
-    ctx.gfx.setTextColor(GRAY);
+    ctx.gfx.setTextColor(Colors::Muted::White);
 
     ctx.gfx.print("Menu:");
     ctx.gfx.setCursor(1, 12);
     if (press)
-        ctx.gfx.setTextColor(WHITE);
+        ctx.gfx.setTextColor(Colors::Bright::White);
     else
-        ctx.gfx.setTextColor(GRAY);
+        ctx.gfx.setTextColor(Colors::Muted::White);
     ctx.gfx.println(label(selected));
 
     // arrow hint
     ctx.gfx.setCursor(1, MATRIX_HEIGHT - 8);
     if (left)
-        ctx.gfx.setTextColor(WHITE);
+        ctx.gfx.setTextColor(Colors::Bright::White);
     else
-        ctx.gfx.setTextColor(GRAY);
+        ctx.gfx.setTextColor(Colors::Muted::White);
     ctx.gfx.print("<");
 
     ctx.gfx.setCursor(10, MATRIX_HEIGHT - 8);
     if (press)
-        ctx.gfx.setTextColor(WHITE);
+        ctx.gfx.setTextColor(Colors::Bright::White);
     else
-        ctx.gfx.setTextColor(GRAY);
+        ctx.gfx.setTextColor(Colors::Muted::White);
     ctx.gfx.print("OK");
 
     if (right)
-        ctx.gfx.setTextColor(WHITE);
+        ctx.gfx.setTextColor(Colors::Bright::White);
     else
-        ctx.gfx.setTextColor(GRAY);
+        ctx.gfx.setTextColor(Colors::Muted::White);
     ctx.gfx.setCursor(MATRIX_WIDTH - 6, MATRIX_HEIGHT - 8);
     ctx.gfx.print(">");
 }

--- a/GRID/MenuScene.h
+++ b/GRID/MenuScene.h
@@ -1,0 +1,115 @@
+#ifndef MENU_SCENE_H
+#define MENU_SCENE_H
+#include "Scene.h"
+#include "SceneBus.h"
+#include <array>
+
+struct MenuScene : public Scene
+{
+    enum class Item : int
+    {
+        Example,
+        Boids,
+        Calibration,
+        COUNT
+    };
+
+    Item selected = Item::Example;
+
+    SceneTimingPrefs timingPrefs() const override
+    {
+        // Default 60Hz is fine; return NaN to keep global default
+        return SceneTimingPrefs(std::numeric_limits<double>::quiet_NaN());
+    }
+
+    void setup(AppContext &ctx) override
+    {
+        // Simple splash
+        ctx.gfx.clear();
+        ctx.gfx.setCursor(1, 0);
+        ctx.gfx.setTextSize(1);
+        ctx.gfx.setTextColor(WHITE);
+        ctx.gfx.println("Menu");
+    }
+
+    void loop(AppContext &ctx) override
+    {
+        const InputState s = ctx.input.state();
+
+        // Basic nav: X left/right to change selection, button to activate
+        // Simple hysteresis with thresholds
+        const float TH = 0.45f;
+        static bool prevLeft = false, prevRight = false, prevPress = false;
+
+        bool left = (s.x < -TH);
+        bool right = (s.x > TH);
+        bool press = s.pressed;
+
+        if (right && !prevRight)
+            next();
+        if (left && !prevLeft)
+            prev();
+
+        // Draw menu each frame
+        draw(ctx);
+
+        if (press && !prevPress && ctx.bus)
+        {
+            switch (selected)
+            {
+            case Item::Example:
+                ctx.bus->toExample();
+                return;
+            case Item::Boids:
+                ctx.bus->toBoids();
+                return;
+            case Item::Calibration:
+                ctx.bus->toCalibration();
+                return;
+            default:
+                break;
+            }
+        }
+
+        prevLeft = left;
+        prevRight = right;
+        prevPress = press;
+    }
+
+private:
+    void next()
+    {
+        int v = static_cast<int>(selected);
+        v = (v + 1) % static_cast<int>(Item::COUNT);
+        selected = static_cast<Item>(v);
+    }
+    void prev()
+    {
+        int v = static_cast<int>(selected);
+        v = (v - 1 + static_cast<int>(Item::COUNT)) % static_cast<int>(Item::COUNT);
+        selected = static_cast<Item>(v);
+    }
+    void draw(AppContext &ctx)
+    {
+        ctx.gfx.clear();
+        ctx.gfx.setTextSize(1);
+        ctx.gfx.setCursor(2, 4);
+
+        auto printItem = [&](const char *label, bool sel)
+        {
+            ctx.gfx.setTextColor(sel ? GREEN : WHITE);
+            ctx.gfx.println(label);
+        };
+
+        printItem("E.g.", selected == Item::Example);
+        printItem("Boids", selected == Item::Boids);
+        printItem("Calib", selected == Item::Calibration);
+
+        // arrow hint
+        ctx.gfx.setCursor(1, MATRIX_HEIGHT - 8);
+        ctx.gfx.setTextColor(WHITE);
+        ctx.gfx.print("<OK>");
+    }
+};
+
+#endif

--- a/GRID/MenuScene.h
+++ b/GRID/MenuScene.h
@@ -27,9 +27,14 @@ struct MenuScene : public Scene
     void loop(AppContext &ctx) override;
 
 private:
+    // Basic nav: X left/right to change selection, button to activate
+    // Simple hysteresis with thresholds
+    static constexpr float HYSTERESIS_THRESHOLD = 0.45f;
+
     void next();
     void prev();
-    void draw(AppContext &ctx);
+    void draw(AppContext &ctx, bool left, bool right, bool press);
+    const char *label(const Item scene) const;
 };
 
 #endif

--- a/GRID/MenuScene.h
+++ b/GRID/MenuScene.h
@@ -30,6 +30,7 @@ private:
     // Basic nav: X left/right to change selection, button to activate
     // Simple hysteresis with thresholds
     static constexpr float HYSTERESIS_THRESHOLD = 0.45f;
+    static const millis_t SELECT_PAUSE = 500; // wait after select for drama
 
     void next();
     void prev();

--- a/GRID/MenuScene.h
+++ b/GRID/MenuScene.h
@@ -22,94 +22,14 @@ struct MenuScene : public Scene
         return SceneTimingPrefs(std::numeric_limits<double>::quiet_NaN());
     }
 
-    void setup(AppContext &ctx) override
-    {
-        // Simple splash
-        ctx.gfx.clear();
-        ctx.gfx.setCursor(1, 0);
-        ctx.gfx.setTextSize(1);
-        ctx.gfx.setTextColor(WHITE);
-        ctx.gfx.println("Menu");
-    }
+    void setup(AppContext &ctx) override {} // no-op
 
-    void loop(AppContext &ctx) override
-    {
-        const InputState s = ctx.input.state();
-
-        // Basic nav: X left/right to change selection, button to activate
-        // Simple hysteresis with thresholds
-        const float TH = 0.45f;
-        static bool prevLeft = false, prevRight = false, prevPress = false;
-
-        bool left = (s.x < -TH);
-        bool right = (s.x > TH);
-        bool press = s.pressed;
-
-        if (right && !prevRight)
-            next();
-        if (left && !prevLeft)
-            prev();
-
-        // Draw menu each frame
-        draw(ctx);
-
-        if (press && !prevPress && ctx.bus)
-        {
-            switch (selected)
-            {
-            case Item::Example:
-                ctx.bus->toExample();
-                return;
-            case Item::Boids:
-                ctx.bus->toBoids();
-                return;
-            case Item::Calibration:
-                ctx.bus->toCalibration();
-                return;
-            default:
-                break;
-            }
-        }
-
-        prevLeft = left;
-        prevRight = right;
-        prevPress = press;
-    }
+    void loop(AppContext &ctx) override;
 
 private:
-    void next()
-    {
-        int v = static_cast<int>(selected);
-        v = (v + 1) % static_cast<int>(Item::COUNT);
-        selected = static_cast<Item>(v);
-    }
-    void prev()
-    {
-        int v = static_cast<int>(selected);
-        v = (v - 1 + static_cast<int>(Item::COUNT)) % static_cast<int>(Item::COUNT);
-        selected = static_cast<Item>(v);
-    }
-    void draw(AppContext &ctx)
-    {
-        ctx.gfx.clear();
-        ctx.gfx.setTextSize(1);
-        ctx.gfx.setCursor(2, 4);
-
-        auto printItem = [&](const char *label, bool sel)
-        {
-            ctx.gfx.setTextColor(sel ? GREEN : WHITE);
-            ctx.gfx.println(label);
-        };
-
-        printItem("E.g.", selected == Item::Example);
-        printItem("Boids", selected == Item::Boids);
-        printItem("Calib", selected == Item::Calibration);
-
-        // arrow hint
-        ctx.gfx.setCursor(1, MATRIX_HEIGHT - 8);
-        ctx.gfx.setTextColor(WHITE);
-        ctx.gfx.print("<OK>");
-    }
+    void next();
+    void prev();
+    void draw(AppContext &ctx);
 };
 
 #endif

--- a/GRID/SceneBus.h
+++ b/GRID/SceneBus.h
@@ -1,0 +1,13 @@
+#ifndef SCENE_BUS_H
+#define SCENE_BUS_H
+#include <functional>
+
+struct SceneBus
+{
+    std::function<void()> toMenu;
+    std::function<void()> toExample;
+    std::function<void()> toBoids;
+    std::function<void()> toCalibration;
+};
+
+#endif

--- a/GRID/ScrollTextHelper.h
+++ b/GRID/ScrollTextHelper.h
@@ -8,7 +8,7 @@
  *
  * Usage:
  *   ScrollText s;
- *   s.prepare("Hello", 1, WHITE, BLACK, true, true);
+ *   s.prepare("Hello", 1, Colors::Bright::White, Colors::Black, true, true);
  *   s.reset(MATRIX_WIDTH, ScrollText::yTopCentered(s.ts));
  *   while (running) { s.step(-1, gfx); }
  */
@@ -20,9 +20,9 @@ struct ScrollText
     /// Text scale (integer, >= 1).
     int ts{1};
     /// Foreground (text) color.
-    Color333 fg{WHITE};
+    Color333 fg{Colors::Bright::White};
     /// Background band color.
-    Color333 bg{BLACK};
+    Color333 bg{Colors::Black};
     /// Whether to fill/clear the text band each frame.
     bool useBg{true};
     /// Looping mode: wrap seamlessly when the banner exits left.
@@ -60,12 +60,12 @@ struct ScrollText
      * @param message          C-string text to scroll.
      * @param scale            Integer scale for the 5x7 font.
      * @param color            Foreground text color.
-     * @param bgColor          Background band color (default BLACK).
+     * @param bgColor          Background band color (default Colors::Black).
      * @param fillBackground   If true, fills the text band each frame.
      * @param shouldLoop       If true, enables seamless looping.
      */
     void prepare(Matrix32 &m, const char *message, int scale, Color333 color,
-                 Color333 bgColor = BLACK, bool fillBackground = true, bool shouldLoop = false)
+                 Color333 bgColor = Colors::Black, bool fillBackground = true, bool shouldLoop = false)
     {
         ts = std::max(1, scale);
         fg = color;

--- a/emulation/SDLMatrix32.cpp
+++ b/emulation/SDLMatrix32.cpp
@@ -421,3 +421,7 @@ LEDcell SDLMatrix32::makeLEDcell() const
     cell.radius = std::max(1, int(0.5f * cell.inner * cell.fill));
     return cell;
 }
+
+// v: 0..7  ->  0..255 with inverse-gamma to brighten low codes
+const Intensity8 SDLMatrix32::kExpand3to8Gamma[8] =
+    {0, 150, 181, 202, 220, 233, 245, 255};

--- a/emulation/SDLMatrix32.h
+++ b/emulation/SDLMatrix32.h
@@ -136,13 +136,16 @@ private:
     // Build LEDcell from current scale and chosen styling.
     LEDcell makeLEDcell() const;
 
+    // v: 0..7  ->  0..255 with inverse-gamma to brighten low codes
+    static const Intensity8 kExpand3to8Gamma[8];
+
     // Converts 0..7 -> 0..255 with rounding
     Intensity8 expand3to8(Intensity3 v)
     {
         // Adding half the divisor before dividing performs round‑to‑nearest: floor((v × 255 + 7/2) / 7)
         // Since we can’t add 3.5 in integers, we use +3 as a close, deterministic half
-        return (Intensity8)((v * 255 + 3) / 7);
-    }
+        return kExpand3to8Gamma[v & 0x7];
+        }
 };
 
 #endif // SDL_MATRIX32_H

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -1,11 +1,9 @@
 #include "App.h"
-#include "BoidsScene.h"
-#include "CalibrationScene.h"
 #include "EmulationLogger.h"
-#include "ExampleScene.h"
 #include "FileStorage.h"
 #include "FixedStepTiming.h"
 #include "IStorage.h"
+#include "MenuScene.h"
 #include "SDLInputProvider.h"
 #include "SDLMatrix32.h"
 #include <SDL.h>
@@ -93,7 +91,7 @@ void run_emulation()
     input.init(&inputProvider);
     App app{gfx, timing, input, logger, storage};
 
-    app.setScene<CalibrationScene>();
+    app.setScene<MenuScene>();
 
     while (running)
     {


### PR DESCRIPTION
## Summary
What does this change do and why?
- :sparkles: Creates a `SceneBus` to trigger scene transitions
- :sparkles: Creates a `MenuScene` that allows Scene selection
- :wrench: Adjust SDL colors to be brighter, matching hardware pixels
- :necktie: When button is held for 5s or longer then released, MenuScene reactivates (quitting current scene)
- :recycle: make Colors constant rather than defines

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs

## Author checklist
- [x] Conventional title (feat:, fix:, refactor:, chore:, docs:)
- [x] Commits are small and clear
- [ ] Comments or README updated if helpful
- [x] clang-format / clang-tidy applied or N/A
