### PR TITLE
Grid 27 save+load scores

### DIFF
--- a/GRID/App.h
+++ b/GRID/App.h
@@ -182,10 +182,10 @@ public:
         { this->setScene<BoidsScene>(); };
         bus.toCalibration = [this]
         { this->setScene<CalibrationScene>(); };
-        bus.toSaveScore = [this](Scene::SceneKind kind, const char *label, int newScore)
+        bus.toSaveScore = [this](int newScore)
         {
             // Create SaveScoreScene with the passed score
-            this->setScene<SaveScoreScene>(kind, label, newScore);
+            this->setScene<SaveScoreScene>(current->kind(), current->label(), newScore);
         };
     }
 

--- a/GRID/App.h
+++ b/GRID/App.h
@@ -19,6 +19,7 @@
 #include "CalibrationScene.h"
 #include "MenuScene.h"
 #include "StartScene.h"
+#include "SaveScoreScene.h"
 
 // App manages the current scene; only holds Matrix32&
 class App
@@ -181,6 +182,12 @@ public:
         { this->setScene<BoidsScene>(); };
         bus.toCalibration = [this]
         { this->setScene<CalibrationScene>(); };
+        bus.toSaveScore = [this](Scene::SceneKind kind, const char *label, int newScore)
+        {
+            // Create SaveScoreScene with the passed score
+            // auto saveScene = std::make_shared<SaveScoreScene>(kind, label, newScore);
+            this->setScene<SaveScoreScene>(kind, label, newScore);
+        };
     }
 
     // Replace the current scene with a newly constructed SceneT.

--- a/GRID/App.h
+++ b/GRID/App.h
@@ -185,7 +185,6 @@ public:
         bus.toSaveScore = [this](Scene::SceneKind kind, const char *label, int newScore)
         {
             // Create SaveScoreScene with the passed score
-            // auto saveScene = std::make_shared<SaveScoreScene>(kind, label, newScore);
             this->setScene<SaveScoreScene>(kind, label, newScore);
         };
     }

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -64,10 +64,6 @@ static uint16_t fps_frames{};
 void setup()
 {
     Serial.begin(115200);
-    while (!Serial) // TODO remove for final build
-    {
-        delay(10);
-    }
 
     randomSeed(analogRead(0));
     pinMode(0, INPUT_PULLUP);

--- a/GRID/GRID.ino
+++ b/GRID/GRID.ino
@@ -65,7 +65,7 @@ void setup()
 {
     Serial.begin(115200);
 
-    randomSeed(analogRead(0));
+    Helpers::randomSeed(analogRead(A0));
     pinMode(0, INPUT_PULLUP);
     inputProvider.init();
     input.init(&inputProvider);

--- a/GRID/Helpers.h
+++ b/GRID/Helpers.h
@@ -22,8 +22,9 @@ namespace Helpers
     template <typename T>
     inline T clamp(T v, T lo, T hi) { return v < lo ? lo : (v > hi ? hi : v); } // Arduino lacks std::clamp
     // Provide a random int between 0..range
-    inline int random(long int range) { return static_cast<float>(rand()) * range / RAND_MAX; }
+    inline int random(long int range) { return rand() % range; }
     inline int random() { return rand(); }
+    inline void randomSeed(unsigned long seed) { srand(seed); }
 }
 
 // Helpers for use by the emulation

--- a/GRID/MazeScene.cpp
+++ b/GRID/MazeScene.cpp
@@ -1,7 +1,6 @@
 #include "MazeScene.h"
 #include "Helpers.h"
 #include "SceneBus.h"
-#include "ScoreData.h"
 #include "Serializer.h"
 #include <vector>
 #include <queue>
@@ -142,14 +141,17 @@ void MazeScene::loop(AppContext &ctx)
             }
             else
             {
-                endState_ = EndGame; // TODO change to ShowHighScore if score > highScore
+                if (loadHighScore(ctx, highScore))
+                    endState_ = ShowHighScore;
+                else // TODO start SaveScoreScene if score > highScore.score
+                    endState_ = EndGame;
                 lastUpdateTime = now;
             }
             break;
         case ShowHighScore:
             if (now - lastUpdateTime < kShowScoreDuration)
             {
-                // showHighScore(ctx); // TODO implement
+                showHighScore(ctx, highScore);
             }
             else
                 endState_ = EndGame;
@@ -770,6 +772,35 @@ void MazeScene::showFinalScore(AppContext &ctx, score_t score)
     char buf[6];
     snprintf(buf, 6, "%d", score);
     ctx.gfx.print(buf);
+}
+
+/**
+ * @brief loads the saved high score
+ *
+ * @returns true if the high score was loaded
+ * @returns false if the load was not successful
+ */
+bool MazeScene::loadHighScore(AppContext &ctx, ScoreData &highScore)
+{
+    char filename[10];
+    snprintf(filename, 10, "%s.%s", label(), highScore.kFileExtension);
+    return highScore.load(ctx.storage, ctx.logger, filename);
+}
+
+void MazeScene::showHighScore(AppContext &ctx, const ScoreData &data)
+{
+    int ts = 1;
+    ctx.gfx.clear();
+    ctx.gfx.setTextSize(ts);
+    ctx.gfx.setTextColor(Colors::Muted::White);
+    ctx.gfx.setCursor(1, 1);
+    ctx.gfx.println("Best:");
+    ctx.gfx.setTextColor(Colors::Muted::Green);
+    ctx.gfx.setCursor(1, 10);
+    ctx.gfx.println(data.name);
+    char buf[6];
+    snprintf(buf, 6, "%d", data.score);
+    ctx.gfx.println(buf);
 }
 
 /**

--- a/GRID/MazeScene.cpp
+++ b/GRID/MazeScene.cpp
@@ -75,12 +75,7 @@ void MazeScene::setStage(AppContext &ctx, Stage newStage)
 
 void MazeScene::setup(AppContext &ctx)
 {
-    // TODO implement file loading
-    ScoreData loadedScore;
-    Serializer::Score::fromJSON("{\"v\": 1\"n\": \"Hello World\",\"s\": 50}", loadedScore);
-    ctx.logger.logf(LogLevel::Debug, "[MazeScene] loaded:\n{ 's': %d, 'n': '%s'}", loadedScore.score, loadedScore.name);
-
-    setStage(ctx, Intro);
+    setStage(ctx, Game); // TODO switch back to Intro once finalized
 }
 
 void MazeScene::loop(AppContext &ctx)
@@ -558,7 +553,7 @@ void MazeScene::movePlayer(AppContext &ctx)
     }
     x = Helpers::clamp(playerX + dx, 1, MATRIX_WIDTH - 2);
     y = Helpers::clamp(playerY + dy, 1, MATRIX_HEIGHT - 2);
-    if (grid[y][x] != HuePalette::Wall)
+    // if (grid[y][x] != HuePalette::Wall) // TODO re-enable
     {
         playerX = x;
         playerY = y;

--- a/GRID/MazeScene.cpp
+++ b/GRID/MazeScene.cpp
@@ -75,7 +75,7 @@ void MazeScene::setStage(AppContext &ctx, Stage newStage)
 
 void MazeScene::setup(AppContext &ctx)
 {
-    setStage(ctx, Game); // TODO switch back to Intro once finalized
+    setStage(ctx, Intro);
 }
 
 void MazeScene::loop(AppContext &ctx)
@@ -585,7 +585,7 @@ void MazeScene::movePlayer(AppContext &ctx)
     }
     x = Helpers::clamp(playerX + dx, 1, MATRIX_WIDTH - 2);
     y = Helpers::clamp(playerY + dy, 1, MATRIX_HEIGHT - 2);
-    // if (grid[y][x] != HuePalette::Wall) // TODO re-enable
+    if (grid[y][x] != HuePalette::Wall)
     {
         playerX = x;
         playerY = y;

--- a/GRID/MazeScene.cpp
+++ b/GRID/MazeScene.cpp
@@ -77,8 +77,8 @@ void MazeScene::setup(AppContext &ctx)
 {
     // TODO implement file loading
     ScoreData loadedScore;
-    Serializer::Score::fromJSON("{\"v\": 1\"n\": \"Bryan\",\"s\": 50}", loadedScore);
-    ctx.logger.logf(LogLevel::Debug, "[MazeScene] loaded:\n{ \"s\": %d, \"n\": \"%s\"}", loadedScore.score, loadedScore.name);
+    Serializer::Score::fromJSON("{\"v\": 1\"n\": \"Hello World\",\"s\": 50}", loadedScore);
+    ctx.logger.logf(LogLevel::Debug, "[MazeScene] loaded:\n{ 's': %d, 'n': '%s'}", loadedScore.score, loadedScore.name);
 
     setStage(ctx, Intro);
 }

--- a/GRID/MazeScene.cpp
+++ b/GRID/MazeScene.cpp
@@ -141,10 +141,16 @@ void MazeScene::loop(AppContext &ctx)
             }
             else
             {
-                if (loadHighScore(ctx, highScore))
+                // if the loaded high score is still the highscore, show it then end the game,
+                if (loadHighScore(ctx, highScore) && highScore.score >= score)
+                {
                     endState_ = ShowHighScore;
-                else // TODO start SaveScoreScene if score > highScore.score
-                    endState_ = EndGame;
+                }
+                else // otherwise transition to SaveScoreScene
+                {
+                    ctx.bus->toSaveScore(this->kind(), this->label(), score);
+                    return;
+                }
                 lastUpdateTime = now;
             }
             break;

--- a/GRID/MazeScene.cpp
+++ b/GRID/MazeScene.cpp
@@ -1,6 +1,8 @@
 #include "MazeScene.h"
 #include "Helpers.h"
 #include "SceneBus.h"
+#include "ScoreData.h"
+#include "Serializer.h"
 #include <vector>
 #include <queue>
 
@@ -73,6 +75,11 @@ void MazeScene::setStage(AppContext &ctx, Stage newStage)
 
 void MazeScene::setup(AppContext &ctx)
 {
+    // TODO implement file loading
+    ScoreData loadedScore;
+    Serializer::Score::fromJSON("{\"v\": 1\"n\": \"Bryan\",\"s\": 50}", loadedScore);
+    ctx.logger.logf(LogLevel::Debug, "[MazeScene] loaded:\n{ \"s\": %d, \"n\": \"%s\"}", loadedScore.score, loadedScore.name);
+
     setStage(ctx, Intro);
 }
 

--- a/GRID/MazeScene.cpp
+++ b/GRID/MazeScene.cpp
@@ -148,7 +148,7 @@ void MazeScene::loop(AppContext &ctx)
                 }
                 else // otherwise transition to SaveScoreScene
                 {
-                    ctx.bus->toSaveScore(this->kind(), this->label(), score);
+                    ctx.bus->toSaveScore(score);
                     return;
                 }
                 lastUpdateTime = now;

--- a/GRID/MazeScene.h
+++ b/GRID/MazeScene.h
@@ -347,6 +347,7 @@ public:
 
     SceneKind kind() const override { return SceneKind::Maze; }
     const char *label() const override { return "Maze"; }
+    int finalScore() { return score; }
 };
 
 #endif // MAZE_SCENE_H

--- a/GRID/MazeScene.h
+++ b/GRID/MazeScene.h
@@ -243,8 +243,7 @@ private:
     void movePlayer(AppContext &ctx);
 
     // Visibility
-    // TODO revert back to 1
-    static constexpr Maze::matrix_t kVisibility = 15; // "Medium" visibility from old game
+    static constexpr Maze::matrix_t kVisibility = 1; // "Medium" visibility from old game
 
     // Snacks
 

--- a/GRID/MazeScene.h
+++ b/GRID/MazeScene.h
@@ -308,7 +308,6 @@ private:
     void displayMaze(AppContext &ctx);
     void displayTimer(AppContext &ctx);
     bool playerHasFinished();
-    void endGame(AppContext &ctx);
 
     // Scoring
 
@@ -318,13 +317,25 @@ private:
     static constexpr score_t kMaxTimeScore = 50; // max score bonus from time left
     // in ms, the time after game start for player to achieve MAX_TIME_SCORE
     static constexpr millis_t kMaxTimeBuffer = (90 * 1000);
-    static constexpr uint8_t kNumSnacks = 15;              // how many snacks to spawn
-    static constexpr score_t kSnackPoints = 2;             // how many points does a snack give
-    static constexpr millis_t kSnackTimeBoost = 1000;      // how much time does a snack give
+    static constexpr uint8_t kNumSnacks = 15;         // how many snacks to spawn
+    static constexpr score_t kSnackPoints = 2;        // how many points does a snack give
+    static constexpr millis_t kSnackTimeBoost = 1000; // how much time does a snack give
+
+    // End State
+
     static constexpr millis_t kShowScoreDuration = (5000); // ms to show final score
-    void computeFinalScore(score_t &score, millis_t nowMs);
+    enum EndState : uint8_t
+    {
+        ShowBanner,
+        ShowFinalScore,
+        ShowHighScore,
+        EndGame
+    };
+    EndState endState_ = ShowBanner;
     ScrollText banner;
-    void showScore(AppContext &ctx, score_t score);
+    void computeFinalScore(score_t &score, millis_t nowMs);
+    void showFinalScore(AppContext &ctx, score_t score);
+    void endGame(AppContext &ctx);
 
 public:
     void setup(AppContext &ctx) override;

--- a/GRID/MazeScene.h
+++ b/GRID/MazeScene.h
@@ -347,7 +347,6 @@ public:
 
     SceneKind kind() const override { return SceneKind::Maze; }
     const char *label() const override { return "Maze"; }
-    int finalScore() { return score; }
 };
 
 #endif // MAZE_SCENE_H

--- a/GRID/MazeScene.h
+++ b/GRID/MazeScene.h
@@ -4,6 +4,7 @@
 #include "Scene.h"
 #include "Colors.h"
 #include "ScrollTextHelper.h"
+#include "ScoreData.h"
 #include <climits>
 #include <bitset>
 
@@ -320,6 +321,7 @@ private:
     static constexpr uint8_t kNumSnacks = 15;         // how many snacks to spawn
     static constexpr score_t kSnackPoints = 2;        // how many points does a snack give
     static constexpr millis_t kSnackTimeBoost = 1000; // how much time does a snack give
+    void computeFinalScore(score_t &score, millis_t nowMs);
 
     // End State
 
@@ -332,9 +334,11 @@ private:
         EndGame
     };
     EndState endState_ = ShowBanner;
+    ScoreData highScore;
     ScrollText banner;
-    void computeFinalScore(score_t &score, millis_t nowMs);
     void showFinalScore(AppContext &ctx, score_t score);
+    bool loadHighScore(AppContext &ctx, ScoreData &highScore);
+    void showHighScore(AppContext &ctx, const ScoreData &data);
     void endGame(AppContext &ctx);
 
 public:

--- a/GRID/MazeScene.h
+++ b/GRID/MazeScene.h
@@ -242,8 +242,8 @@ private:
     void movePlayer(AppContext &ctx);
 
     // Visibility
-
-    static constexpr Maze::matrix_t kVisibility = 1; // "Medium" visibility from old game
+    // TODO revert back to 1
+    static constexpr Maze::matrix_t kVisibility = 15; // "Medium" visibility from old game
 
     // Snacks
 

--- a/GRID/RGBMatrix32.cpp
+++ b/GRID/RGBMatrix32.cpp
@@ -176,7 +176,7 @@ void RGBMatrix32::fillCircle(int cx, int cy, int r, Color333 c)
 // Text helpers
 
 // Move cursor by 1 glyph (5px + 1px spacing) at current scale
-void RGBMatrix32::advance() { cx += ts * 6; }
+void RGBMatrix32::advance() { cx += ts * FONT_CHAR_WIDTH; }
 
 // Set text cursor
 void RGBMatrix32::setCursor(int x, int y)
@@ -196,10 +196,10 @@ void RGBMatrix32::setTextSize(int s) { ts = std::max(1, s); }
 void RGBMatrix32::drawChar(int x, int y, char ch, Color333 c)
 {
     const PixelMap *glyph = FONT5x7[ch - ASCII_START];
-    for (int col = 0; col < 5; ++col)
+    for (int col = 0; col < FONT_GLYPH_WIDTH; ++col)
     {
         PixelColumn bits = glyph[col];
-        for (int row = 0; row < 7; ++row)
+        for (int row = 0; row < FONT_GLYPH_HEIGHT; ++row)
             if (bits & (1u << row))
                 drawPixelScaled(x + col, y + row, c);
     }
@@ -213,7 +213,7 @@ void RGBMatrix32::print(char ch)
     if (ch == '\n')
     {
         cx = lineStartX;
-        cy += ts * 8;
+        cy += ts * (FONT_CHAR_HEIGHT + 1);
         return;
     }
     if (ch < ASCII_START)

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -150,12 +150,27 @@ void SaveScoreScene::drawCarets(AppContext &ctx, int tx, int ty)
 {
     InputState s = ctx.input.state();
     Color333 tc;
+    millis_t now = ctx.time.nowMs();
+    // get current character index in alphabet
+    alphabetIndex_ = (strchr(kAlphabet, payload_.name[cursorIndex_]) - kAlphabet);
 
     // Basic nav: X up/down to change char
-    static bool prevUp = false, prevDown = false;
+    static bool prevUp = 0, prevDown = 0;
+    static millis_t prevUpTime = 0, prevDownTime = 0;
 
     bool up = (s.y < -HYSTERESIS_THRESHOLD);
     bool down = (s.y > HYSTERESIS_THRESHOLD);
+
+    if (up && (!prevUp || (now - prevUpTime > kAlphabetStrobeDelay)))
+    {
+        moveUp();
+        prevUpTime = now;
+    }
+    if (down && (!prevDown || (now - prevDownTime > kAlphabetStrobeDelay)))
+    {
+        moveDown();
+        prevDownTime = now;
+    }
 
     // Draw up caret (assuming textSize = 1)
     tc = (up ? kSelectedColor : kTextColor);
@@ -169,4 +184,16 @@ void SaveScoreScene::drawCarets(AppContext &ctx, int tx, int ty)
 
     prevUp = up;
     prevDown = down;
+}
+
+void SaveScoreScene::moveUp()
+{
+    alphabetIndex_ = (alphabetIndex_ + 1) % kAlphabetSize;
+    payload_.name[cursorIndex_] = kAlphabet[alphabetIndex_];
+}
+
+void SaveScoreScene::moveDown()
+{
+    alphabetIndex_ = (alphabetIndex_ - 1 + kAlphabetSize) % kAlphabetSize;
+    payload_.name[cursorIndex_] = kAlphabet[alphabetIndex_];
 }

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -89,5 +89,50 @@ void SaveScoreScene::showSaved(AppContext &ctx)
 
 void SaveScoreScene::handleInputName(AppContext &ctx)
 {
-    ctx.gfx.clear(); // TODO implement input name
+    InputState s = ctx.input.state();
+
+    // Basic nav: X left/right to change cursor, up/down to change char
+    static bool prevLeft = false, prevRight = false;
+
+    bool left = (s.x < -HYSTERESIS_THRESHOLD);
+    bool right = (s.x > HYSTERESIS_THRESHOLD);
+
+    if (left && !prevLeft)
+        moveLeft();
+    if (right && !prevRight)
+        moveRight();
+
+    drawName(ctx);
+
+    prevLeft = left;
+    prevRight = right;
+}
+
+void SaveScoreScene::moveLeft()
+{
+    if (cursorIndex_ > 0)
+        --cursorIndex_;
+}
+
+void SaveScoreScene::moveRight()
+{
+    if (cursorIndex_ < payload_.kMaxNameLength - 1)
+        ++cursorIndex_;
+}
+
+void SaveScoreScene::drawName(AppContext &ctx)
+{
+    int ts = 1;
+    int tStartX = 1;
+    int tStartY = 12;
+    ctx.gfx.clear();
+    ctx.gfx.setTextSize(ts);
+    ctx.gfx.setTextColor(Colors::Muted::White);
+    for (int i = 0; i < payload_.kMaxNameLength; ++i)
+    {
+        int tx = i * FONT_CHAR_WIDTH + tStartX;
+        int ty = tStartY;
+        Color333 tc = (i == cursorIndex_ ? Colors::Bright::White : Colors::Muted::White);
+        ctx.gfx.drawChar(tx, ty, payload_.name[i], tc);
+    }
 }

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -91,7 +91,7 @@ void SaveScoreScene::handleInputName(AppContext &ctx)
 {
     InputState s = ctx.input.state();
 
-    // Basic nav: X left/right to change cursor, up/down to change char
+    // Basic nav: X left/right to change cursor
     static bool prevLeft = false, prevRight = false;
 
     bool left = (s.x < -HYSTERESIS_THRESHOLD);
@@ -132,7 +132,41 @@ void SaveScoreScene::drawName(AppContext &ctx)
     {
         int tx = i * FONT_CHAR_WIDTH + tStartX;
         int ty = tStartY;
-        Color333 tc = (i == cursorIndex_ ? Colors::Bright::White : Colors::Muted::White);
+        Color333 tc;
+        if (i == cursorIndex_)
+        {
+            tc = kSelectedColor;
+            drawCarets(ctx, tx, ty);
+        }
+        else
+        {
+            tc = kTextColor;
+        }
         ctx.gfx.drawChar(tx, ty, payload_.name[i], tc);
     }
+}
+
+void SaveScoreScene::drawCarets(AppContext &ctx, int tx, int ty)
+{
+    InputState s = ctx.input.state();
+    Color333 tc;
+
+    // Basic nav: X up/down to change char
+    static bool prevUp = false, prevDown = false;
+
+    bool up = (s.y < -HYSTERESIS_THRESHOLD);
+    bool down = (s.y > HYSTERESIS_THRESHOLD);
+
+    // Draw up caret (assuming textSize = 1)
+    tc = (up ? kSelectedColor : kTextColor);
+    ctx.gfx.drawLine(tx, ty - 2, tx + 2, ty - 4, tc);
+    ctx.gfx.drawLine(tx + 3, ty - 3, tx + 4, ty - 2, tc);
+
+    // Draw down caret (assuming textSize = 1)
+    tc = (down ? kSelectedColor : kTextColor);
+    ctx.gfx.drawLine(tx, ty + FONT_CHAR_HEIGHT + 1, tx + 2, ty + FONT_CHAR_HEIGHT + 3, tc);
+    ctx.gfx.drawLine(tx + 3, ty + FONT_CHAR_HEIGHT + 2, tx + 4, ty + FONT_CHAR_HEIGHT + 1, tc);
+
+    prevUp = up;
+    prevDown = down;
 }

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -1,9 +1,63 @@
 #include "SaveScoreScene.h"
 
+void SaveScoreScene::setStage(AppContext &ctx, Stage newStage)
+{
+    switch (newStage)
+    {
+    case Stage::ShowIntro:
+
+        break;
+    case Stage::InputName:
+
+        break;
+    case Stage::ShowSaved:
+
+        break;
+    case Stage::End:
+
+        break;
+    }
+    startTime = ctx.time.nowMs();
+    stage = newStage;
+}
+
 void SaveScoreScene::setup(AppContext &ctx)
 {
+    setStage(ctx, Stage::ShowIntro);
 }
 
 void SaveScoreScene::loop(AppContext &ctx)
 {
+    millis_t now = ctx.time.nowMs();
+    switch (stage)
+    {
+    case Stage::ShowIntro:
+        if (now - startTime < kShowTextDuration)
+            showIntro(ctx);
+        else
+            setStage(ctx, Stage::InputName);
+        break;
+    case Stage::InputName:
+        ctx.gfx.clear(); // TODO implement name input
+        break;
+
+    case Stage::ShowSaved:
+
+        break;
+    case Stage::End:
+
+        break;
+    }
+}
+
+void SaveScoreScene::showIntro(AppContext &ctx)
+{
+    int ts = 1;
+    ctx.gfx.clear();
+    ctx.gfx.setTextSize(ts);
+    ctx.gfx.setTextColor(Colors::Muted::White);
+    ctx.gfx.setCursor(1, 1);
+    ctx.gfx.println("Input");
+    ctx.gfx.println("Your");
+    ctx.gfx.println("Name");
 }

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -1,0 +1,9 @@
+#include "SaveScoreScene.h"
+
+void SaveScoreScene::setup(AppContext &ctx)
+{
+}
+
+void SaveScoreScene::loop(AppContext &ctx)
+{
+}

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -3,21 +3,6 @@
 
 void SaveScoreScene::setStage(AppContext &ctx, Stage newStage)
 {
-    switch (newStage)
-    {
-    case Stage::ShowIntro:
-
-        break;
-    case Stage::InputName:
-
-        break;
-    case Stage::ShowSaved:
-
-        break;
-    case Stage::End:
-
-        break;
-    }
     startTime_ = ctx.time.nowMs();
     stage_ = newStage;
 }
@@ -43,8 +28,10 @@ void SaveScoreScene::loop(AppContext &ctx)
         InputState state = ctx.input.state();
         if (state.pressed) // submit name once button is pressed
         {
-            // TODO implement submit storage
-            setStage(ctx, Stage::ShowSaved);
+            if (submitScoreData(ctx, payload_))
+                setStage(ctx, Stage::ShowSaved);
+            else
+                setStage(ctx, Stage::ShowError);
         }
         else
         {
@@ -55,6 +42,12 @@ void SaveScoreScene::loop(AppContext &ctx)
     case Stage::ShowSaved:
         if (now - startTime_ < kShowTextDuration)
             showSaved(ctx);
+        else
+            setStage(ctx, Stage::End);
+        break;
+    case Stage::ShowError:
+        if (now - startTime_ < kShowTextDuration)
+            showError(ctx);
         else
             setStage(ctx, Stage::End);
         break;
@@ -85,6 +78,19 @@ void SaveScoreScene::showSaved(AppContext &ctx)
     ctx.gfx.setCursor(1, 1);
     ctx.gfx.println("Score");
     ctx.gfx.println("Saved");
+}
+
+void SaveScoreScene::showError(AppContext &ctx)
+{
+    int ts = 1;
+    ctx.gfx.clear();
+    ctx.gfx.setTextSize(ts);
+    ctx.gfx.setTextColor(Colors::Muted::White);
+    ctx.gfx.setCursor(1, 1);
+    ctx.gfx.println("Score");
+    ctx.gfx.println("Save");
+    ctx.gfx.setTextColor(Colors::Muted::Red);
+    ctx.gfx.println("Error");
 }
 
 void SaveScoreScene::handleInputName(AppContext &ctx)
@@ -196,4 +202,9 @@ void SaveScoreScene::moveDown()
 {
     alphabetIndex_ = (alphabetIndex_ - 1 + kAlphabetSize) % kAlphabetSize;
     payload_.name[cursorIndex_] = kAlphabet[alphabetIndex_];
+}
+
+bool SaveScoreScene::submitScoreData(AppContext &ctx, ScoreData &payload)
+{
+    return false; // TODO implement
 }

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -1,4 +1,5 @@
 #include "SaveScoreScene.h"
+#include "SceneBus.h"
 
 void SaveScoreScene::setStage(AppContext &ctx, Stage newStage)
 {
@@ -17,8 +18,8 @@ void SaveScoreScene::setStage(AppContext &ctx, Stage newStage)
 
         break;
     }
-    startTime = ctx.time.nowMs();
-    stage = newStage;
+    startTime_ = ctx.time.nowMs();
+    stage_ = newStage;
 }
 
 void SaveScoreScene::setup(AppContext &ctx)
@@ -29,23 +30,36 @@ void SaveScoreScene::setup(AppContext &ctx)
 void SaveScoreScene::loop(AppContext &ctx)
 {
     millis_t now = ctx.time.nowMs();
-    switch (stage)
+    switch (stage_)
     {
     case Stage::ShowIntro:
-        if (now - startTime < kShowTextDuration)
+        if (now - startTime_ < kShowTextDuration)
             showIntro(ctx);
         else
             setStage(ctx, Stage::InputName);
         break;
     case Stage::InputName:
-        ctx.gfx.clear(); // TODO implement name input
+    {
+        InputState state = ctx.input.state();
+        if (state.pressed) // submit name once button is pressed
+        {
+            // TODO implement submit storage
+            setStage(ctx, Stage::ShowSaved);
+        }
+        else
+        {
+            handleInputName(ctx);
+        }
         break;
-
+    }
     case Stage::ShowSaved:
-
+        if (now - startTime_ < kShowTextDuration)
+            showSaved(ctx);
+        else
+            setStage(ctx, Stage::End);
         break;
     case Stage::End:
-
+        ctx.bus->toMenu();
         break;
     }
 }
@@ -60,4 +74,20 @@ void SaveScoreScene::showIntro(AppContext &ctx)
     ctx.gfx.println("Input");
     ctx.gfx.println("Your");
     ctx.gfx.println("Name");
+}
+
+void SaveScoreScene::showSaved(AppContext &ctx)
+{
+    int ts = 1;
+    ctx.gfx.clear();
+    ctx.gfx.setTextSize(ts);
+    ctx.gfx.setTextColor(Colors::Muted::White);
+    ctx.gfx.setCursor(1, 1);
+    ctx.gfx.println("Score");
+    ctx.gfx.println("Saved");
+}
+
+void SaveScoreScene::handleInputName(AppContext &ctx)
+{
+    ctx.gfx.clear(); // TODO implement input name
 }

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -206,5 +206,7 @@ void SaveScoreScene::moveDown()
 
 bool SaveScoreScene::submitScoreData(AppContext &ctx, ScoreData &payload)
 {
-    return false; // TODO implement
+    char filename[10];
+    snprintf(filename, 10, "%s.%s", originLabel_, payload.kFileExtension);
+    return payload.save(ctx.storage, ctx.logger, filename);
 }

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -213,13 +213,13 @@ void SaveScoreScene::drawCarets(AppContext &ctx, int tx, int ty)
 
 void SaveScoreScene::moveUp()
 {
-    alphabetIndex_ = (alphabetIndex_ + 1) % kAlphabetSize;
+    alphabetIndex_ = (alphabetIndex_ - 1 + kAlphabetSize) % kAlphabetSize;
     payload_.name[cursorIndex_] = kAlphabet[alphabetIndex_];
 }
 
 void SaveScoreScene::moveDown()
 {
-    alphabetIndex_ = (alphabetIndex_ - 1 + kAlphabetSize) % kAlphabetSize;
+    alphabetIndex_ = (alphabetIndex_ + 1) % kAlphabetSize;
     payload_.name[cursorIndex_] = kAlphabet[alphabetIndex_];
 }
 

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -1,6 +1,12 @@
 #include "SaveScoreScene.h"
 #include "SceneBus.h"
 
+constexpr Color333 SaveScoreScene::kTextColor;
+constexpr Color333 SaveScoreScene::kSelectedColor;
+constexpr Color333 SaveScoreScene::kSubmitColor;
+constexpr Color333 SaveScoreScene::kErrorColor;
+constexpr char SaveScoreScene::kAlphabet[];
+
 void SaveScoreScene::setStage(AppContext &ctx, Stage newStage)
 {
     startTime_ = ctx.time.nowMs();

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -25,11 +25,12 @@ void SaveScoreScene::loop(AppContext &ctx)
         break;
     case Stage::InputName:
     {
-        InputState state = ctx.input.state();
-        if (state.pressed) // submit name once button is pressed
+        if (submit_) // submit name once button is pressed
         {
             if (submitScoreData(ctx, payload_))
+            {
                 setStage(ctx, Stage::ShowSaved);
+            }
             else
                 setStage(ctx, Stage::ShowError);
         }
@@ -62,7 +63,7 @@ void SaveScoreScene::showIntro(AppContext &ctx)
     int ts = 1;
     ctx.gfx.clear();
     ctx.gfx.setTextSize(ts);
-    ctx.gfx.setTextColor(Colors::Muted::White);
+    ctx.gfx.setTextColor(kTextColor);
     ctx.gfx.setCursor(1, 1);
     ctx.gfx.println("Input");
     ctx.gfx.println("Your");
@@ -74,9 +75,10 @@ void SaveScoreScene::showSaved(AppContext &ctx)
     int ts = 1;
     ctx.gfx.clear();
     ctx.gfx.setTextSize(ts);
-    ctx.gfx.setTextColor(Colors::Muted::White);
+    ctx.gfx.setTextColor(kTextColor);
     ctx.gfx.setCursor(1, 1);
     ctx.gfx.println("Score");
+    ctx.gfx.setTextColor(kSubmitColor);
     ctx.gfx.println("Saved");
 }
 
@@ -85,11 +87,11 @@ void SaveScoreScene::showError(AppContext &ctx)
     int ts = 1;
     ctx.gfx.clear();
     ctx.gfx.setTextSize(ts);
-    ctx.gfx.setTextColor(Colors::Muted::White);
+    ctx.gfx.setTextColor(kTextColor);
     ctx.gfx.setCursor(1, 1);
     ctx.gfx.println("Score");
     ctx.gfx.println("Save");
-    ctx.gfx.setTextColor(Colors::Muted::Red);
+    ctx.gfx.setTextColor(kErrorColor);
     ctx.gfx.println("Error");
 }
 
@@ -109,6 +111,12 @@ void SaveScoreScene::handleInputName(AppContext &ctx)
         moveRight();
 
     drawName(ctx);
+
+    if (submit_)
+    {
+        ctx.gfx.show();
+        ctx.time.sleep(SELECT_WAIT);
+    }
 
     prevLeft = left;
     prevRight = right;
@@ -147,6 +155,11 @@ void SaveScoreScene::drawName(AppContext &ctx)
         else
         {
             tc = kTextColor;
+        }
+        if (ctx.input.state().pressed)
+        {
+            tc = kSubmitColor;
+            submit_ = true;
         }
         ctx.gfx.drawChar(tx, ty, payload_.name[i], tc);
     }

--- a/GRID/SaveScoreScene.cpp
+++ b/GRID/SaveScoreScene.cpp
@@ -102,8 +102,8 @@ void SaveScoreScene::handleInputName(AppContext &ctx)
     // Basic nav: X left/right to change cursor
     static bool prevLeft = false, prevRight = false;
 
-    bool left = (s.x < -HYSTERESIS_THRESHOLD);
-    bool right = (s.x > HYSTERESIS_THRESHOLD);
+    bool left = (s.x < -kHysteresisThreshold);
+    bool right = (s.x > kHysteresisThreshold);
 
     if (left && !prevLeft)
         moveLeft();
@@ -115,7 +115,7 @@ void SaveScoreScene::handleInputName(AppContext &ctx)
     if (submit_)
     {
         ctx.gfx.show();
-        ctx.time.sleep(SELECT_WAIT);
+        ctx.time.sleep(kSubmitPause);
     }
 
     prevLeft = left;
@@ -177,8 +177,8 @@ void SaveScoreScene::drawCarets(AppContext &ctx, int tx, int ty)
     static bool prevUp = 0, prevDown = 0;
     static millis_t prevUpTime = 0, prevDownTime = 0;
 
-    bool up = (s.y < -HYSTERESIS_THRESHOLD);
-    bool down = (s.y > HYSTERESIS_THRESHOLD);
+    bool up = (s.y < -kHysteresisThreshold);
+    bool down = (s.y > kHysteresisThreshold);
 
     if (up && (!prevUp || (now - prevUpTime > kAlphabetStrobeDelay)))
     {

--- a/GRID/SaveScoreScene.h
+++ b/GRID/SaveScoreScene.h
@@ -14,6 +14,8 @@ class SaveScoreScene : public Scene
     static constexpr millis_t kAlphabetStrobeDelay = 300; // ms to wait between pulses of select input
     static constexpr Color333 kTextColor = Colors::Muted::White;
     static constexpr Color333 kSelectedColor = ColorHSV333(0, 0, 150);
+    static constexpr Color333 kSubmitColor = Colors::Muted::Green;
+    static constexpr Color333 kErrorColor = Colors::Muted::Red;
     static constexpr int kAlphabetSize = 27;
     static constexpr char kAlphabet[kAlphabetSize + 1] = "_ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     const SceneKind origin_;
@@ -22,6 +24,7 @@ class SaveScoreScene : public Scene
     millis_t startTime_ = 0;
     int cursorIndex_ = 0;
     int alphabetIndex_ = 0;
+    bool submit_ = false;
 
     enum Stage
     {

--- a/GRID/SaveScoreScene.h
+++ b/GRID/SaveScoreScene.h
@@ -10,7 +10,7 @@ class SaveScoreScene : public Scene
     const SceneKind origin_;
     const char *originLabel_;
     ScoreData payload_;
-    millis_t startTime = 0;
+    millis_t startTime_ = 0;
 
     enum Stage
     {
@@ -19,10 +19,12 @@ class SaveScoreScene : public Scene
         ShowSaved,
         End
     };
-    Stage stage = Stage::ShowIntro;
+    Stage stage_ = Stage::ShowIntro;
 
     void setStage(AppContext &ctx, Stage newStage);
     void showIntro(AppContext &ctx);
+    void handleInputName(AppContext &ctx);
+    void showSaved(AppContext &ctx);
 
 public:
     SaveScoreScene(SceneKind kind, const char *label, int newScore) : origin_(kind), originLabel_(label)

--- a/GRID/SaveScoreScene.h
+++ b/GRID/SaveScoreScene.h
@@ -3,6 +3,7 @@
 
 #include "Scene.h"
 #include "ScoreData.h"
+#include "Colors.h"
 
 class SaveScoreScene : public Scene
 {
@@ -10,6 +11,8 @@ class SaveScoreScene : public Scene
     static constexpr float HYSTERESIS_THRESHOLD = 0.45f;  // Simple hysteresis with thresholds
     static const millis_t SELECT_WAIT = 500;              // wait after select for drama
     static constexpr millis_t kShowTextDuration = (3000); // ms to show a text
+    static constexpr Color333 kTextColor = Colors::Muted::White;
+    static constexpr Color333 kSelectedColor = ColorHSV333(0, 0, 150);
     const SceneKind origin_;
     const char *originLabel_;
     ScoreData payload_;
@@ -31,6 +34,7 @@ class SaveScoreScene : public Scene
     void moveLeft();
     void moveRight();
     void drawName(AppContext &ctx);
+    void drawCarets(AppContext &ctx, int tx, int ty);
     void showSaved(AppContext &ctx);
 
 public:

--- a/GRID/SaveScoreScene.h
+++ b/GRID/SaveScoreScene.h
@@ -6,9 +6,23 @@
 
 class SaveScoreScene : public Scene
 {
+    static constexpr millis_t kShowTextDuration = (3000); // ms to show a text
     const SceneKind origin_;
     const char *originLabel_;
     ScoreData payload_;
+    millis_t startTime = 0;
+
+    enum Stage
+    {
+        ShowIntro,
+        InputName,
+        ShowSaved,
+        End
+    };
+    Stage stage = Stage::ShowIntro;
+
+    void setStage(AppContext &ctx, Stage newStage);
+    void showIntro(AppContext &ctx);
 
 public:
     SaveScoreScene(SceneKind kind, const char *label, int newScore) : origin_(kind), originLabel_(label)

--- a/GRID/SaveScoreScene.h
+++ b/GRID/SaveScoreScene.h
@@ -9,15 +9,19 @@ class SaveScoreScene : public Scene
 {
     // Basic nav: X left/right to change selection, button to activate
     static constexpr float HYSTERESIS_THRESHOLD = 0.45f;  // Simple hysteresis with thresholds
-    static const millis_t SELECT_WAIT = 500;              // wait after select for drama
+    static constexpr millis_t SELECT_WAIT = 500;          // wait after select for drama
     static constexpr millis_t kShowTextDuration = (3000); // ms to show a text
+    static constexpr millis_t kAlphabetStrobeDelay = 300; // ms to wait between pulses of select input
     static constexpr Color333 kTextColor = Colors::Muted::White;
     static constexpr Color333 kSelectedColor = ColorHSV333(0, 0, 150);
+    static constexpr int kAlphabetSize = 27;
+    static constexpr char kAlphabet[kAlphabetSize + 1] = "_ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     const SceneKind origin_;
     const char *originLabel_;
     ScoreData payload_;
     millis_t startTime_ = 0;
     int cursorIndex_ = 0;
+    int alphabetIndex_ = 0;
 
     enum Stage
     {
@@ -33,6 +37,8 @@ class SaveScoreScene : public Scene
     void handleInputName(AppContext &ctx);
     void moveLeft();
     void moveRight();
+    void moveUp();
+    void moveDown();
     void drawName(AppContext &ctx);
     void drawCarets(AppContext &ctx, int tx, int ty);
     void showSaved(AppContext &ctx);
@@ -43,6 +49,7 @@ public:
         payload_.score = newScore;
         for (int i = 0; i < payload_.kMaxNameLength; ++i)
             payload_.name[i] = '_';
+        payload_.name[payload_.kMaxNameLength] = 0;
     }
 
     SceneKind kind() const override { return SceneKind::SaveScore; }

--- a/GRID/SaveScoreScene.h
+++ b/GRID/SaveScoreScene.h
@@ -28,6 +28,7 @@ class SaveScoreScene : public Scene
         ShowIntro,
         InputName,
         ShowSaved,
+        ShowError,
         End
     };
     Stage stage_ = Stage::ShowIntro;
@@ -41,7 +42,9 @@ class SaveScoreScene : public Scene
     void moveDown();
     void drawName(AppContext &ctx);
     void drawCarets(AppContext &ctx, int tx, int ty);
+    bool submitScoreData(AppContext &ctx, ScoreData &payload);
     void showSaved(AppContext &ctx);
+    void showError(AppContext &ctx);
 
 public:
     SaveScoreScene(SceneKind kind, const char *label, int newScore) : origin_(kind), originLabel_(label)

--- a/GRID/SaveScoreScene.h
+++ b/GRID/SaveScoreScene.h
@@ -1,0 +1,27 @@
+#ifndef SAVE_SCORE_SCENE_H
+#define SAVE_SCORE_SCENE_H
+
+#include "Scene.h"
+#include "ScoreData.h"
+
+class SaveScoreScene : public Scene
+{
+    const SceneKind origin_;
+    const char *originLabel_;
+    ScoreData payload_;
+
+public:
+    SaveScoreScene(SceneKind kind, const char *label, int newScore) : origin_(kind), originLabel_(label)
+    {
+        payload_.score = newScore;
+    }
+
+    SceneKind kind() const override { return SceneKind::SaveScore; }
+    const char *label() const override { return "SaveScore"; }
+
+    void setup(AppContext &ctx) override;
+
+    void loop(AppContext &ctx) override;
+};
+
+#endif

--- a/GRID/SaveScoreScene.h
+++ b/GRID/SaveScoreScene.h
@@ -8,8 +8,8 @@
 class SaveScoreScene : public Scene
 {
     // Basic nav: X left/right to change selection, button to activate
-    static constexpr float HYSTERESIS_THRESHOLD = 0.45f;  // Simple hysteresis with thresholds
-    static constexpr millis_t SELECT_WAIT = 500;          // wait after select for drama
+    static constexpr float kHysteresisThreshold = 0.45f;  // Simple hysteresis with thresholds
+    static constexpr millis_t kSubmitPause = 100;         // wait after select for drama
     static constexpr millis_t kShowTextDuration = (3000); // ms to show a text
     static constexpr millis_t kAlphabetStrobeDelay = 300; // ms to wait between pulses of select input
     static constexpr Color333 kTextColor = Colors::Muted::White;

--- a/GRID/SaveScoreScene.h
+++ b/GRID/SaveScoreScene.h
@@ -6,11 +6,15 @@
 
 class SaveScoreScene : public Scene
 {
+    // Basic nav: X left/right to change selection, button to activate
+    static constexpr float HYSTERESIS_THRESHOLD = 0.45f;  // Simple hysteresis with thresholds
+    static const millis_t SELECT_WAIT = 500;              // wait after select for drama
     static constexpr millis_t kShowTextDuration = (3000); // ms to show a text
     const SceneKind origin_;
     const char *originLabel_;
     ScoreData payload_;
     millis_t startTime_ = 0;
+    int cursorIndex_ = 0;
 
     enum Stage
     {
@@ -24,12 +28,17 @@ class SaveScoreScene : public Scene
     void setStage(AppContext &ctx, Stage newStage);
     void showIntro(AppContext &ctx);
     void handleInputName(AppContext &ctx);
+    void moveLeft();
+    void moveRight();
+    void drawName(AppContext &ctx);
     void showSaved(AppContext &ctx);
 
 public:
     SaveScoreScene(SceneKind kind, const char *label, int newScore) : origin_(kind), originLabel_(label)
     {
         payload_.score = newScore;
+        for (int i = 0; i < payload_.kMaxNameLength; ++i)
+            payload_.name[i] = '_';
     }
 
     SceneKind kind() const override { return SceneKind::SaveScore; }

--- a/GRID/Scene.h
+++ b/GRID/Scene.h
@@ -20,7 +20,8 @@ struct Scene
     Boids,
     Calibration,
     Maze,
-    Test
+    Test,
+    SaveScore
   };
 
   virtual ~Scene() = default;

--- a/GRID/SceneBus.h
+++ b/GRID/SceneBus.h
@@ -1,5 +1,6 @@
 #ifndef SCENE_BUS_H
 #define SCENE_BUS_H
+#include "Scene.h"
 #include <functional>
 
 struct SceneBus
@@ -8,6 +9,7 @@ struct SceneBus
     std::function<void()> toMaze;
     std::function<void()> toBoids;
     std::function<void()> toCalibration;
+    std::function<void(Scene::SceneKind, const char *, int)> toSaveScore;
 };
 
 #endif

--- a/GRID/SceneBus.h
+++ b/GRID/SceneBus.h
@@ -9,7 +9,7 @@ struct SceneBus
     std::function<void()> toMaze;
     std::function<void()> toBoids;
     std::function<void()> toCalibration;
-    std::function<void(Scene::SceneKind, const char *, int)> toSaveScore;
+    std::function<void(int)> toSaveScore;
 };
 
 #endif

--- a/GRID/ScoreData.cpp
+++ b/GRID/ScoreData.cpp
@@ -3,32 +3,37 @@
 #include "IStorage.h"
 #include "Logging.h"
 
+size_t ScoreData::toJSON(char *dst, size_t cap) const
+{
+    return Serializer::Score::toJSON(*this, dst, cap);
+}
+
 bool ScoreData::fromJSON(const char *src)
 {
     return Serializer::Score::fromJSON(src, *this);
 }
 
-// bool ScoreData::save(IStorage &storage, ILogger &log, const char *filename) const
-// {
-//     char json[kJsonCap]{};
-//     const size_t n = toJSON(json, sizeof(json));
-//     if (n == 0)
-//     {
-//         log.logf(LogLevel::Warning, "[%s] toJSON failed", kLogTag);
-//         return false;
-//     }
-//     if (storage.writeAll(filename, json, n))
-//     {
-//         log.logf(LogLevel::Debug, "Calibration Saved:\n%s", json);
-//     }
-//     else
-//     {
-//         log.logf(LogLevel::Warning, "[%s] writeAll failed", kLogTag);
-//         return false;
-//     }
-//     log.logf(LogLevel::Info, "[%s] saved %u bytes to %s", kLogTag, static_cast<unsigned>(n), filename);
-//     return true;
-// }
+bool ScoreData::save(IStorage &storage, ILogger &log, const char *filename) const
+{
+    char json[kJsonCap]{};
+    const size_t n = toJSON(json, sizeof(json));
+    if (n == 0)
+    {
+        log.logf(LogLevel::Warning, "[%s] toJSON failed", kLogTag);
+        return false;
+    }
+    if (storage.writeAll(filename, json, n))
+    {
+        log.logf(LogLevel::Debug, "Score Saved to '%s':\n%s", filename, json);
+    }
+    else
+    {
+        log.logf(LogLevel::Warning, "[%s] writeAll failed", kLogTag);
+        return false;
+    }
+    log.logf(LogLevel::Info, "[%s] saved %u bytes to %s", kLogTag, static_cast<unsigned>(n), filename);
+    return true;
+}
 
 bool ScoreData::load(IStorage &storage, ILogger &log, const char *filename)
 {

--- a/GRID/ScoreData.cpp
+++ b/GRID/ScoreData.cpp
@@ -1,0 +1,53 @@
+#include "ScoreData.h"
+#include "Serializer.h"
+#include "IStorage.h"
+#include "Logging.h"
+
+bool ScoreData::fromJSON(const char *src)
+{
+    return Serializer::Score::fromJSON(src, *this);
+}
+
+// bool ScoreData::save(IStorage &storage, ILogger &log, const char *filename) const
+// {
+//     char json[kJsonCap]{};
+//     const size_t n = toJSON(json, sizeof(json));
+//     if (n == 0)
+//     {
+//         log.logf(LogLevel::Warning, "[%s] toJSON failed", kLogTag);
+//         return false;
+//     }
+//     if (storage.writeAll(filename, json, n))
+//     {
+//         log.logf(LogLevel::Debug, "Calibration Saved:\n%s", json);
+//     }
+//     else
+//     {
+//         log.logf(LogLevel::Warning, "[%s] writeAll failed", kLogTag);
+//         return false;
+//     }
+//     log.logf(LogLevel::Info, "[%s] saved %u bytes to %s", kLogTag, static_cast<unsigned>(n), filename);
+//     return true;
+// }
+
+bool ScoreData::load(IStorage &storage, ILogger &log, const char *filename)
+{
+    char buf[kReadCap]{};
+    const auto r = storage.readAll(filename, buf, sizeof(buf));
+    if (!r)
+    {
+        log.logf(LogLevel::Info, "[%s] %s not found or read failed", kLogTag, filename);
+        return false;
+    }
+    if (fromJSON(buf))
+    {
+        log.logf(LogLevel::Debug, "Score Loaded from '%s':\n%s", filename, buf);
+    }
+    else
+    {
+        log.logf(LogLevel::Warning, "[%s] fromJSON failed", kLogTag);
+        return false;
+    }
+    log.logf(LogLevel::Info, "[%s] loaded %d bytes from %s", kLogTag, r.bytes, filename);
+    return true;
+}

--- a/GRID/ScoreData.h
+++ b/GRID/ScoreData.h
@@ -1,12 +1,30 @@
 #ifndef SCORE_DATA_H
 #define SCORE_DATA_H
 
+#include <cstdint>
+#include <stddef.h>
+
+// forward decl
+struct IStorage;
+struct ILogger;
+
 // represents a Game score with name
 struct ScoreData
 {
     static constexpr uint8_t kMaxNameLength = 5;
+    static constexpr size_t kJsonCap = 100;
+    static constexpr size_t kReadCap = 100;
+    static constexpr const char *kLogTag = "Score";
+    static constexpr const char *kFileExtension = "dat";
     int score;                     // the integer score in the Maze game
     char name[kMaxNameLength + 1]; // +1 to leave space for NULL terminator
+
+    // Parse JSON into this object. Returns true on success.
+    bool fromJSON(const char *src);
+
+    // Save/load using IStorage (atomic write) with default filename.
+    // bool save(IStorage &storage, ILogger &log, const char *filename = "calibration.json") const; // TODO implement
+    bool load(IStorage &storage, ILogger &log, const char *filename);
 };
 
 #endif // SCORE_DATA_H

--- a/GRID/ScoreData.h
+++ b/GRID/ScoreData.h
@@ -1,0 +1,12 @@
+#ifndef SCORE_DATA_H
+#define SCORE_DATA_H
+
+// represents a Game score with name
+struct ScoreData
+{
+    static constexpr uint8_t kMaxNameLength = 5;
+    int score;                     // the integer score in the Maze game
+    char name[kMaxNameLength + 1]; // +1 to leave space for NULL terminator
+};
+
+#endif // SCORE_DATA_H

--- a/GRID/ScoreData.h
+++ b/GRID/ScoreData.h
@@ -19,11 +19,15 @@ struct ScoreData
     int score;                     // the integer score in the Maze game
     char name[kMaxNameLength + 1]; // +1 to leave space for NULL terminator
 
+    // Serialize this object to JSON into dst.
+    // Returns bytes written, or 0 on failure.
+    size_t toJSON(char *dst, size_t cap) const;
+
     // Parse JSON into this object. Returns true on success.
     bool fromJSON(const char *src);
 
     // Save/load using IStorage (atomic write) with default filename.
-    // bool save(IStorage &storage, ILogger &log, const char *filename = "calibration.json") const; // TODO implement
+    bool save(IStorage &storage, ILogger &log, const char *filename) const;
     bool load(IStorage &storage, ILogger &log, const char *filename);
 };
 

--- a/GRID/Serializer.cpp
+++ b/GRID/Serializer.cpp
@@ -5,6 +5,7 @@
 // - Suitable for tiny payloads (<< 512 bytes).
 #include "Serializer.h"
 #include "Input.h"
+#include "ScoreData.h"
 #include <stdio.h>  // snprintf
 #include <stdlib.h> // strtol, strtof
 #include <string.h> // strstr, strchr
@@ -140,6 +141,26 @@ static bool findNumF(const char *s, const char *key, float &v)
     return true;
 }
 
+// Internal helper: find str at key "key" in 's' and store into 'buf'.
+// Returns true on success; does not modify 'v' if key is not present.
+static bool findStr(const char *s, const char *key, char *buf)
+{
+    const char *p = strstr(s, key);
+    if (!p)
+        return false;
+    p = strchr(p, ':');
+    if (!p)
+        return false;
+    p = strchr(p, '"');
+    if (!p)
+        return false;
+    const char *end = strrchr(p + 1, '"');
+    if (end == p + 1)
+        return false; // missing closing quote
+    memcpy(buf, p + 1, ScoreData::kMaxNameLength);
+    return true;
+}
+
 size_t Serializer::Calibration::toJSON(const InputCalibration &c, char *dst, size_t cap)
 {
     // Prepare float fields as strings since many Arduino libc builds lack printf float.
@@ -195,6 +216,31 @@ bool Serializer::Calibration::fromJSON(const char *src, InputCalibration &out)
         out.y_adc_center = (uint16_t)li;
     if (findNumI(src, "\"yh\"", li))
         out.y_adc_high = (uint16_t)li;
+
+    // If the JSON was present but missing some keys, we still succeed and
+    // keep the default values in 'out' for the missing keys.
+    return true;
+}
+
+bool Serializer::Score::fromJSON(const char *src, ScoreData &out)
+{
+    // Basic validation
+    if (!src || !*src)
+        return false;
+
+    // Version is optional and currently unused; read and ignore.
+    long vi = 0;
+    (void)vi;
+    findNumI(src, "\"v\"", vi);
+
+    char buf[ScoreData::kMaxNameLength];
+    if (findStr(src, "\"n\"", buf))
+        memcpy(out.name, buf, ScoreData::kMaxNameLength);
+
+    // Integers (ADC points)
+    long li = 0;
+    if (findNumI(src, "\"s\"", li))
+        out.score = (uint16_t)li;
 
     // If the JSON was present but missing some keys, we still succeed and
     // keep the default values in 'out' for the missing keys.

--- a/GRID/Serializer.cpp
+++ b/GRID/Serializer.cpp
@@ -222,6 +222,17 @@ bool Serializer::Calibration::fromJSON(const char *src, InputCalibration &out)
     return true;
 }
 
+size_t Serializer::Score::toJSON(const ScoreData &s, char *dst, size_t cap)
+{
+    // Emit compact, order-stable JSON.
+    int n = snprintf(dst, cap,
+                     "{\"v\":%u,\"n\":\"%s\",\"s\":%d}",
+                     1u, s.name, s.score);
+    if (n <= 0 || (size_t)n >= cap)
+        return 0;
+    return (size_t)n;
+}
+
 bool Serializer::Score::fromJSON(const char *src, ScoreData &out)
 {
     // Basic validation

--- a/GRID/Serializer.cpp
+++ b/GRID/Serializer.cpp
@@ -141,9 +141,9 @@ static bool findNumF(const char *s, const char *key, float &v)
     return true;
 }
 
-// Internal helper: find str at key "key" in 's' and store into 'buf'.
+// Internal helper: find str at key "key" in 's' and store into 'buf' (up to len).
 // Returns true on success; does not modify 'v' if key is not present.
-static bool findStr(const char *s, const char *key, char *buf)
+static bool findStr(const char *s, const char *key, char *buf, size_t len)
 {
     const char *p = strstr(s, key);
     if (!p)
@@ -154,10 +154,10 @@ static bool findStr(const char *s, const char *key, char *buf)
     p = strchr(p, '"');
     if (!p)
         return false;
-    const char *end = strrchr(p + 1, '"');
-    if (end == p + 1)
-        return false; // missing closing quote
-    memcpy(buf, p + 1, ScoreData::kMaxNameLength);
+    const char *end = strchr(p + 1, '"');
+    if (end == p + 1) // missing closing quote
+        return false;
+    memcpy(buf, p + 1, len);
     return true;
 }
 
@@ -234,7 +234,7 @@ bool Serializer::Score::fromJSON(const char *src, ScoreData &out)
     findNumI(src, "\"v\"", vi);
 
     char buf[ScoreData::kMaxNameLength];
-    if (findStr(src, "\"n\"", buf))
+    if (findStr(src, "\"n\"", buf, ScoreData::kMaxNameLength))
         memcpy(out.name, buf, ScoreData::kMaxNameLength);
 
     // Integers (ADC points)

--- a/GRID/Serializer.h
+++ b/GRID/Serializer.h
@@ -19,7 +19,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-struct InputCalibration; // forward decl
+// forward decl
+struct InputCalibration;
+struct ScoreData;
 
 struct Serializer
 {
@@ -42,6 +44,20 @@ struct Serializer
         // - Extra fields are ignored.
         // - Version ("v") is optional and reserved for future migrations.
         static bool fromJSON(const char *src, InputCalibration &out);
+    };
+
+    // Serialization helpers for ScoreData
+    // JSON shape:
+    //   {"v": 1,"n":"John","s":100}
+    struct Score
+    {
+        // Parse JSON from 'src' (null-terminated) into 'out'.
+        // Returns: true on success, false on invalid input.
+        // Notes:
+        // - Missing fields are left at 'out' defaults.
+        // - Extra fields are ignored.
+        // - Version ("v") is optional and reserved for future migrations.
+        static bool fromJSON(const char *src, ScoreData &out);
     };
 };
 

--- a/GRID/Serializer.h
+++ b/GRID/Serializer.h
@@ -51,6 +51,13 @@ struct Serializer
     //   {"v": 1,"n":"John","s":100}
     struct Score
     {
+        // Serialize 'c' to JSON into 'dst' with capacity 'cap'.
+        // Returns: number of bytes written (excluding terminating '\0'), or 0 on failure.
+        // Notes:
+        // - Uses short keys to save bytes: v,dz,gm,xl,xc,xh,yl,yc,yh.
+        // - Float formatting uses %.4g for compactness and readability.
+        static size_t toJSON(const ScoreData &s, char *dst, size_t cap);
+
         // Parse JSON from 'src' (null-terminated) into 'out'.
         // Returns: true on success, false on invalid input.
         // Notes:

--- a/emulation/SDLMatrix32.cpp
+++ b/emulation/SDLMatrix32.cpp
@@ -226,7 +226,7 @@ void SDLMatrix32::print(char ch)
     if (ch == '\n')
     {
         cx = lineStartX;
-        cy += ts * FONT_CHAR_HEIGHT;
+        cy += ts * (FONT_CHAR_HEIGHT + 1);
         return;
     }
     if (ch < ASCII_START)

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -10,9 +10,6 @@
 #include <algorithm>
 #include <cstdint>
 
-// TODO remove
-#include "SaveScoreScene.h"
-
 // match GRID hardware
 static constexpr double TICK_HZ = 60.0;
 
@@ -57,8 +54,7 @@ void run_emulation()
     input.init(&inputProvider);
     App app{gfx, timing, input, logger, storage};
 
-    // TODO reset once done
-    app.setScene<SaveScoreScene>(Scene::SceneKind::Maze, "Maze", 99);
+    app.setScene<StartScene>();
 
     while (running)
     {

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -9,6 +9,7 @@
 #include <SDL.h>
 #include <algorithm>
 #include <cstdint>
+#include <chrono>
 
 // match GRID hardware
 static constexpr double TICK_HZ = 60.0;
@@ -16,6 +17,11 @@ static constexpr double TICK_HZ = 60.0;
 // Main emulation loop
 void run_emulation()
 {
+    // unsigned long seed = static_cast<unsigned long>(
+    //     std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    unsigned long seed = 1l; // use consistent seed for emulation testing
+    Helpers::randomSeed(seed);
+
     FileStorage storage;
     SDLMatrix32 gfx{};
     gfx.begin();

--- a/emulation/main.cpp
+++ b/emulation/main.cpp
@@ -10,6 +10,9 @@
 #include <algorithm>
 #include <cstdint>
 
+// TODO remove
+#include "SaveScoreScene.h"
+
 // match GRID hardware
 static constexpr double TICK_HZ = 60.0;
 
@@ -54,7 +57,8 @@ void run_emulation()
     input.init(&inputProvider);
     App app{gfx, timing, input, logger, storage};
 
-    app.setScene<StartScene>();
+    // TODO reset once done
+    app.setScene<SaveScoreScene>(Scene::SceneKind::Maze, "Maze", 99);
 
     while (running)
     {


### PR DESCRIPTION
## Summary
What does this change do and why?
- :sparkles: adds a SaveScore scene
- :floppy_disk: enables saving/loading ScoreData
- :necktie: when Maze score is best, than transition to SaveScore scene to save ScoreData
- :wrench: remove debug guards

## Type of change
- [x] Feature

## Approach
How did you implement it? Any tradeoffs or alternatives considered?
- in SaveScore scene, name can be input by a character scroll input


## Author checklist
- [x] Conventional title (feat:, fix:, refactor:, chore:, docs:)
- [x] Commits are small and clear
- [ ] Comments or README updated if helpful
- [x] clang-format / clang-tidy applied or N/A
